### PR TITLE
#55 fix: deactive tableview scroll

### DIFF
--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -133,6 +133,7 @@ class MainViewController: UIViewController {
         let topicTableView = UITableView()
         topicTableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
         topicTableView.reloadData()
+        topicTableView.isScrollEnabled = false
         return topicTableView
     }()
 


### PR DESCRIPTION
## 개요
TableView의 스크롤을 못하게 만들었습니다

<br/>

## 작업사항
### 작업 사항
한줄 컷

```swift
topicTableView.isScrollEnabled = false
```

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)
<img width="330" alt="스크린샷 2022-07-25 오전 9 51 28" src="https://user-images.githubusercontent.com/59143479/180673859-a5842d12-4da6-4562-a66e-48dc7a1559c2.png">

### 진행 예정 사항
ex) 작업 진행 예정사항 및 개선하고 싶은 내용이 있다면 추가 해주세요
- [ ] 셀이 길어질 때 ... 으로 처리하지 않고 동적으로 Cell 길이 늘려주기

Closed #55