### PR TITLE
Feature/74 세팅 뷰 구현 및 백 투 포그라운드 작업

### DIFF
--- a/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
+++ b/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Cma-4u-btn">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
@@ -14,7 +15,7 @@
             <objects>
                 <viewController id="h9C-xi-h1l" customClass="TabBarController" customModule="TodayAnbu" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="wuN-Gx-mkO">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="h7e-CH-ujs"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -30,7 +31,6 @@
             <objects>
                 <navigationController navigationBarHidden="YES" id="Cma-4u-btn" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="PmX-JR-Rgg">
-                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -46,29 +46,29 @@
             <objects>
                 <viewController id="H6m-4V-Raq" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="OvF-j1-dXT">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="혹시 부모님이 갱년기 같으신가요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1eV-IS-3iG">
-                                <rect key="frame" x="140.5" y="405.5" width="319" height="29"/>
+                                <rect key="frame" x="47.5" y="619.5" width="319" height="29"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="갱년기는 급격한 호르몬 변화를 겪는 시기로" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDk-mg-it6">
-                                <rect key="frame" x="173.5" y="454.5" width="253.5" height="18"/>
+                                <rect key="frame" x="80.5" y="668.5" width="253.5" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 대표적인 증상으로 무기력함과 우울감이 있어요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TyM-vL-RDw">
-                                <rect key="frame" x="158" y="480.5" width="284" height="18"/>
+                                <rect key="frame" x="65" y="694.5" width="284" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IY4-tW-qWX">
-                                <rect key="frame" x="20" y="539.5" width="52" height="31"/>
+                                <rect key="frame" x="20" y="822.5" width="52" height="31"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Skip"/>
@@ -77,7 +77,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="szI-PR-2gr">
-                                <rect key="frame" x="526" y="539.5" width="54" height="31"/>
+                                <rect key="frame" x="340" y="822.5" width="54" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Next"/>
                                 <connections>
@@ -85,7 +85,7 @@
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dadPicture" translatesAutoresizingMaskIntoConstraints="NO" id="Ab0-3b-621">
-                                <rect key="frame" x="49" y="125.5" width="502" height="229"/>
+                                <rect key="frame" x="-44" y="191.5" width="502" height="341.5"/>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="rmL-0a-M5c"/>
@@ -118,32 +118,32 @@
             <objects>
                 <viewController id="lyG-OF-ikj" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HGk-3c-Ohq">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="momPicture" translatesAutoresizingMaskIntoConstraints="NO" id="7nc-8V-HKl">
-                                <rect key="frame" x="-17" y="165" width="634" height="150"/>
+                                <rect key="frame" x="-110" y="250.5" width="634" height="224"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="부모님께 얼마나 자주 안부전화하나요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3HO-e8-lu3">
-                                <rect key="frame" x="119.5" y="405.5" width="361" height="29"/>
+                                <rect key="frame" x="26.5" y="619.5" width="361" height="29"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="안부를 묻는 것만으로 갱년기 우울감 " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y5B-ds-Wwi">
-                                <rect key="frame" x="192.5" y="454.5" width="215" height="18"/>
+                                <rect key="frame" x="99.5" y="668.5" width="215" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완화에 도움이 된다고 해요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ycP-kV-iHe">
-                                <rect key="frame" x="220" y="480.5" width="160" height="18"/>
+                                <rect key="frame" x="127" y="694.5" width="160" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L7O-UY-DRG">
-                                <rect key="frame" x="20" y="539.5" width="52" height="31"/>
+                                <rect key="frame" x="20" y="822.5" width="52" height="31"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Skip"/>
@@ -152,7 +152,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g3a-fE-OqV">
-                                <rect key="frame" x="526" y="539.5" width="54" height="31"/>
+                                <rect key="frame" x="340" y="822.5" width="54" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Next"/>
                                 <connections>
@@ -190,35 +190,35 @@
             <objects>
                 <viewController id="NtZ-78-jYv" customClass="OnboardingMainViewController" customModule="TodayAnbu" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YPE-9m-1MH">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="“부모님과 가까워지며" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ADn-HQ-d5a">
-                                <rect key="frame" x="20" y="120" width="212" height="30"/>
+                                <rect key="frame" x="20" y="189" width="212" height="30"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="함께 갱년기를 이겨나가요 ! &quot;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8t4-E2-kdY">
-                                <rect key="frame" x="20" y="158" width="280" height="30"/>
+                                <rect key="frame" x="20" y="227" width="280" height="30"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="저희가 연락을 도와드릴게요" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2F2-DC-QjR">
-                                <rect key="frame" x="17" y="236" width="164" height="18"/>
+                                <rect key="frame" x="17" y="358.5" width="164" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="연락이 가능한 시간과 대화하실 분을 선택해주세요!" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u7F-ax-mVe">
-                                <rect key="frame" x="17" y="253" width="297" height="18"/>
+                                <rect key="frame" x="17" y="375.5" width="297" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sWU-HB-90u">
-                                <rect key="frame" x="30" y="410.5" width="540" height="108"/>
+                                <rect key="frame" x="30" y="560" width="354" height="71"/>
                                 <inset key="titleEdgeInsets" minX="-4" minY="0.0" maxX="4" maxY="0.0"/>
                                 <inset key="imageEdgeInsets" minX="-4" minY="0.0" maxX="4" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
@@ -233,7 +233,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iaf-vk-LJJ">
-                                <rect key="frame" x="30" y="276" width="540" height="108"/>
+                                <rect key="frame" x="30" y="463" width="354" height="70.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="iaf-vk-LJJ" secondAttribute="height" multiplier="5:1" id="Oka-yQ-Rkz"/>
                                 </constraints>
@@ -251,7 +251,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDx-zU-TUQ">
-                                <rect key="frame" x="20" y="506.5" width="560" height="93.5"/>
+                                <rect key="frame" x="20" y="799.5" width="374" height="62.5"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="GDx-zU-TUQ" secondAttribute="height" multiplier="6:1" id="3i8-Z5-aIH"/>
@@ -315,13 +315,13 @@
         <!--User Init View Controller-->
         <scene sceneID="MWo-Rp-OkQ">
             <objects>
-                <viewController id="4Mc-d9-Cdu" customClass="UserInitViewController" customModule="TodayAnbu" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="UserInitViewController" id="4Mc-d9-Cdu" customClass="UserInitViewController" customModule="TodayAnbu" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="h2M-uD-n9d">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g7z-be-atv">
-                                <rect key="frame" x="30" y="500" width="540" height="55"/>
+                                <rect key="frame" x="30" y="762" width="354" height="55"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="VXw-CS-WK9"/>
@@ -344,19 +344,19 @@
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Vah-c9-XoB">
-                                <rect key="frame" x="20" y="35" width="560" height="246"/>
+                                <rect key="frame" x="20" y="79" width="374" height="246"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="JYo-rh-Smd">
-                                        <rect key="frame" x="0.0" y="0.0" width="560" height="91"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="91"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="어머니의 연락처를 입력해주세요!" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1tY-fh-lLc">
-                                                <rect key="frame" x="0.0" y="0.0" width="560" height="29"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="29"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="어머니의 전화번호가 무엇인가요?" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kwk-Gg-msr">
-                                                <rect key="frame" x="0.0" y="41" width="560" height="50"/>
+                                                <rect key="frame" x="0.0" y="41" width="374" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="50" id="ysF-xR-Tba"/>
                                                 </constraints>
@@ -366,7 +366,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Qon-NT-LhR">
-                                        <rect key="frame" x="0.0" y="116" width="560" height="130"/>
+                                        <rect key="frame" x="0.0" y="116" width="374" height="130"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="130" id="S8V-l3-kIm"/>
                                         </constraints>
@@ -377,7 +377,7 @@
                                 </constraints>
                             </stackView>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="wheels" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DWi-DD-i5O">
-                                <rect key="frame" x="140" y="204" width="320" height="216"/>
+                                <rect key="frame" x="47" y="466" width="320" height="216"/>
                                 <date key="date" timeIntervalSinceReferenceDate="680443200.35427201">
                                     <!--2022-07-25 12:00:00 +0000-->
                                 </date>

--- a/TodayAnbu/Sources/Controllers/ConfirmViewController.swift
+++ b/TodayAnbu/Sources/Controllers/ConfirmViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class ConfirmViewController: UIViewController {
-    var observer: NSObjectProtocol?
 
     // label 한개랑 버튼 두개 만들어야 함
     private let confirmLabel: UILabel = {
@@ -38,14 +37,6 @@ class ConfirmViewController: UIViewController {
     }()
     override func viewDidLoad() {
         super.viewDidLoad()
-//        observer = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) {
-//            [unowned self] notification in
-//            print("work!")
-//            configureUI()
-//        }
-    }
-    deinit {
-        NotificationCenter.default.removeObserver(observer!)
     }
 
     func configureUI() {

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -187,11 +187,9 @@ class MainViewController: UIViewController {
         configureRender()
         // configureCheckButtonTapGesture()
         self.navigationItem.setHidesBackButton(true, animated: true)
-        observer = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) {
-            [unowned self] notification in
-            print("work!")
+        observer = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) { [unowned self] _ in
             self.present(confirmView, animated: true) {
-                confirmView.configureUI()
+                self.confirmView.configureUI()
             }
         }
     }

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -7,6 +7,8 @@
 import UIKit
 
 class MainViewController: UIViewController {
+    var observer: NSObjectProtocol?
+    let confirmView = ConfirmViewController()
     // MARK: - Properties
     private var genericTopics = [["최근에 가고 싶은 여행지가 있나요?", "가장 좋았던 여행지가 어디인가요?", "가장 최근에 다녀온 여행지가 어디인가요?", "여행"], ["최근에 본 영화가 있나요?", "가장 좋아하는 영화가 무엇인가요?", "보고 싶은 영화가 있나요?", "영화"], ["최근에 읽은 책이 있나요?", "읽고 싶은 책이 있나요?", "가장 감명 깊게 읽은 책이 무엇인가요?", "책"], ["가장 좋아하는 음악 장르는 무엇인가요?", "최근 들어 자주 듣는 노래가 있으신가요?", "좋아하는 가수가 있으신가요?", "음악"], ["고양이가 좋으세요? 강아지가 좋으세요?", "반려동물을 키운다면 어떨 것 같나요?", "앵무새나 물고기처럼 기르고 싶은 특별한 반려동물이 있나요?", "반려동물"], ["어떤 술을 좋아하시나요?", "음료 중에 어떤게 가장 좋으세요?", "차는 어떤게 좋으세요?", "음료"], ["좋아하는 스포츠가 있으신가요?", "재밌게 보는 스포츠가 있나요?", "운동 좋아하세요?", "스포츠"], ["취미가 무엇인가요?", "새로 배워보고 싶은 취미가 있나요?", "과거에 즐겨했었던 취미가 있나요?", "취미"], ["최근에 복날에 닭은 드셨나요?", "생일 때 뭐 받고 싶으신 게 있나요?", "결혼기념일에 뭐 하실지 생각해보셨어요?", "기념일"]]
     private var seriousTopics = [["최근에 뉴스에 나온 oo 사건 보셨어요?", "ㅇㅇ 정치인에 대해 어떻게 생각하세요?", "ㅇㅇ 정책에 대해 어떻게 생각하세요?", "사회 & 정치"], ["은퇴에 대한 걱정이 있으신가요?", "새로 하시는 일은 어떠세요?", "(이직/퇴사) 어떻게 하는게 좋을까요?", "진로"], ["주변에 괜찮은 사람 소개 좀 시켜줘요", "아는분 자녀 중에 결혼한 사람들 있어요?", "결혼한 사람들이 결혼에 대해서 어떻게 생각한대요?", "만남"], ["환율 어떨거 같아요?", "주식 어떨거 같아요?", "부동산 어떨거 같아요?", "경제"], ["사이가 안좋은 가족이 있다면 현재 어떠신지?", "지금 어머님/아버님에게 서운한 부분이 있으신가요?", "도움이 필요한데 말씀 못 하고 계시진 않나요?", "가족사"], ["금전적으로 도와드려야 할까요?", "(형제/자매) 요즘 괜찮대요?", "현재 우리 가정에 빚이 얼마나 있나요?", "가족의 경제현황"], ["지금 솔직하게 어떤게 제일 불편하세요?", "도움이 필요한데 말씀 못 하고 계시진 않나요?", "배우자에게 건강상 이상한 점을 보신적이 있나요?", "건강"]]
@@ -185,7 +187,18 @@ class MainViewController: UIViewController {
         configureRender()
         // configureCheckButtonTapGesture()
         self.navigationItem.setHidesBackButton(true, animated: true)
+        observer = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) {
+            [unowned self] notification in
+            print("work!")
+            self.present(confirmView, animated: true) {
+                confirmView.configureUI()
+            }
+        }
     }
+    deinit {
+        NotificationCenter.default.removeObserver(observer!)
+    }
+
     // MARK: - Configures
     private func configureUI() {
         view.backgroundColor = .systemBackground

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -77,11 +77,6 @@ extension SettingViewController: UITableViewDataSource {
         return 60.0
     }
 
-    // Header Title
-//    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-//        return "설정"
-//    }
-
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         tableCellHeader
     }
@@ -97,10 +92,7 @@ extension SettingViewController: UITableViewDelegate {
 //    }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-//        let storyboard = UIStoryboard(name: String(describing: UserInitViewController.self), bundle: nil)
         let userinitViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "UserInitViewController")
-//        userinitViewController.delegate = self
-//        storyboard.instantiateInitialViewController()!
         self.navigationController?.pushViewController(userinitViewController, animated: true)
     }
 }

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -10,19 +10,47 @@ import UIKit
 class SettingViewController: UIViewController {
     // MARK: Properties
     let tableView = UITableView(frame: .zero, style: .insetGrouped)
-    let personalMenu = ["요약", "가족 연락처", "알림", "토픽", "About us", "License"]
+    let personalMenu = ["어머니 설정", "아버지 설정", "알림"]
+    let tableViewSection: [String] = ["설정", "추가정보"]
+
+    private let settingTopArea: UIView = {
+        let area = UIView()
+        area.layer.cornerRadius = 20
+        area.backgroundColor = .mainIndigo
+        return area
+    }()
+
+    private let tableCellHeader: UILabel = {
+        let label = UILabel()
+        label.text = "설정"
+        label.font = .systemFont(ofSize: 20, weight: .semibold)
+        label.textColor = .systemGray
+        return label
+    }()
+
+    // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         configureViewComponent()
     }
+
     func configureViewComponent() {
         view.addSubview(tableView)
+        view.addSubview(settingTopArea)
+        settingTopArea.translatesAutoresizingMaskIntoConstraints = false
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(SettingPersonalDataCell.self, forCellReuseIdentifier: "Cell")
+
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            settingTopArea.topAnchor.constraint(equalTo: view.topAnchor),
+            settingTopArea.bottomAnchor.constraint(equalTo: view.topAnchor, constant: 150),
+            settingTopArea.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            settingTopArea.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: settingTopArea.bottomAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             tableView.leftAnchor.constraint(equalTo: view.leftAnchor),
             tableView.rightAnchor.constraint(equalTo: view.rightAnchor)
@@ -31,9 +59,6 @@ class SettingViewController: UIViewController {
 }
 
 extension SettingViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return personalMenu.count
-    }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as? SettingPersonalDataCell else {
             return UITableViewCell()
@@ -44,17 +69,37 @@ extension SettingViewController: UITableViewDataSource {
         return cell
     }
 
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return personalMenu.count
+    }
+    // Header Height
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 60.0
+    }
+
+    // Header Title
+//    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+//        return "설정"
+//    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        tableCellHeader
+    }
 }
 
 extension SettingViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = SettingHeaderView()
-        return header
-    }
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 300
-    }
+//    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+//        let header = SettingHeaderView()
+//        return header
+//    }
+//    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+//        return 300
+//    }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+//        let storyboard = UIStoryboard(name: String(describing: UserInitViewController.self), bundle: nil)
+        let userinitViewController = UserInitViewController(nibName: "UserinitVC", bundle: nil)
+//        storyboard.instantiateInitialViewController()!
+        self.navigationController?.pushViewController(userinitViewController, animated: true)
     }
 }

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -98,7 +98,8 @@ extension SettingViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 //        let storyboard = UIStoryboard(name: String(describing: UserInitViewController.self), bundle: nil)
-        let userinitViewController = UserInitViewController(nibName: "UserinitVC", bundle: nil)
+        let userinitViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "UserInitViewController")
+//        userinitViewController.delegate = self
 //        storyboard.instantiateInitialViewController()!
         self.navigationController?.pushViewController(userinitViewController, animated: true)
     }


### PR DESCRIPTION
## 개요
세팅 뷰 디테일 작업 전 임시 pr 및 백 투 포 그라운드 로직작업 전 뷰 띄우기 성공
<br/>

## 작업사항
### 작업 사항
세팅 뷰에서 스토리 보드의 유저정보 입력창으로 이동
백그라운드 상태에서 포그라운드로 돌아왔을 때 체크 뷰 생성

### References
ex) 작업시 참고한 자료가 있다면 추가해주세요!
  - [background to foreground](https://tdcian.tistory.com/163)
  - [작업내용](URL)

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)

<p align="left">
  <img width="300" alt="화면1" src="https://user-images.githubusercontent.com/81131715/181434024-a1335121-7adf-4e75-91b9-3b8caa9fa90c.gif">
  <img width="300" alt="화면2" src="https://user-images.githubusercontent.com/81131715/181434148-4fb0bcfd-2f5a-4300-b23f-d8f426efe4a9.gif">
</p>



<br/>

## 그외
### 리뷰 포인트
ex) 리뷰받고 싶은 내용, 고민한 내용  등에 대해 적어주세요
- 아무거나 해주세요

### 진행 예정 사항
ex) 작업 진행 예정사항 및 개선하고 싶은 내용이 있다면 추가 해주세요
- [ ] 어머니 아버지 세팅 뷰 이동 구별
- [ ] 액션시트에서 어머니,아버지 클릭 시 체크박스로 값 넘기는 로직 구현 
close #74 
close #53 