### PR TITLE
Feat/70 89 call check view

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,11 +17,6 @@ disabled_rules:
     - function_body_length
     - type_body_length
     - trailing_whitespace
-<<<<<<< HEAD
-    
-=======
-
->>>>>>> develop
 # Default가 비활성화인 규칙을 활성화시키기
 opt_in_rules:
     # .count==0 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_count.html

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,10 +16,8 @@ disabled_rules:
     - file_length
     - function_body_length
     - type_body_length
-
     - trailing_whitespace
-
-    - function_body_length
+    
 # Default가 비활성화인 규칙을 활성화시키기
 opt_in_rules:
     # .count==0 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_count.html

--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A9128868F7100530B51 /* NotificationModalViewController.swift */; };
 		A9B32A94288691EA00530B51 /* NotificationTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A93288691EA00530B51 /* NotificationTime.swift */; };
 		B52841CB28922D7E004A2204 /* CallCheck.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B52841CA28922D7E004A2204 /* CallCheck.storyboard */; };
+		B52841D128926DA7004A2204 /* CallCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52841D028926DA7004A2204 /* CallCheckViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		A9B32A9128868F7100530B51 /* NotificationModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModalViewController.swift; sourceTree = "<group>"; };
 		A9B32A93288691EA00530B51 /* NotificationTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTime.swift; sourceTree = "<group>"; };
 		B52841CA28922D7E004A2204 /* CallCheck.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CallCheck.storyboard; sourceTree = "<group>"; };
+		B52841D028926DA7004A2204 /* CallCheckViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCheckViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 		103BD8EB287FB31C00A6A0AD /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				B52841D028926DA7004A2204 /* CallCheckViewController.swift */,
 				7B9B56992887EE3700FF3DD1 /* ConfirmViewController.swift */,
 				3EC0D9CA28801E9F00A98E73 /* UserInitViewController.swift */,
 				7B2E9C712884FCF4006BE5C8 /* MainViewController.swift */,
@@ -271,6 +274,7 @@
 				7B9B569A2887EE3700FF3DD1 /* ConfirmViewController.swift in Sources */,
 				A9B32A94288691EA00530B51 /* NotificationTime.swift in Sources */,
 				3E2F655F287FA0E600A27FA9 /* AppDelegate.swift in Sources */,
+				B52841D128926DA7004A2204 /* CallCheckViewController.swift in Sources */,
 				7B2E9C722884FCF4006BE5C8 /* MainViewController.swift in Sources */,
 				7BD2303E288E8B18002BB9F5 /* UIColor+Extension.swift in Sources */,
 				A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */,

--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A9332C77288E908F001A1B76 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9332C76288E908F001A1B76 /* DateFormatting.swift */; };
 		A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A9128868F7100530B51 /* NotificationModalViewController.swift */; };
 		A9B32A94288691EA00530B51 /* NotificationTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A93288691EA00530B51 /* NotificationTime.swift */; };
+		B52841CB28922D7E004A2204 /* CallCheck.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B52841CA28922D7E004A2204 /* CallCheck.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +51,7 @@
 		A9332C76288E908F001A1B76 /* DateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
 		A9B32A9128868F7100530B51 /* NotificationModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModalViewController.swift; sourceTree = "<group>"; };
 		A9B32A93288691EA00530B51 /* NotificationTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTime.swift; sourceTree = "<group>"; };
+		B52841CA28922D7E004A2204 /* CallCheck.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CallCheck.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,11 +69,8 @@
 			isa = PBXGroup;
 			children = (
 				3EC0D9CC2880FAD500A98E73 /* UITextfieldExtension.swift */,
-
 				A9332C76288E908F001A1B76 /* DateFormatting.swift */,
-
 				7BD2303D288E8B18002BB9F5 /* UIColor+Extension.swift */,
-
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -124,6 +123,7 @@
 			children = (
 				3E2F6564287FA0E600A27FA9 /* Main.storyboard */,
 				3E2F6569287FA0E700A27FA9 /* LaunchScreen.storyboard */,
+				B52841CA28922D7E004A2204 /* CallCheck.storyboard */,
 			);
 			path = Boards;
 			sourceTree = "<group>";
@@ -228,6 +228,7 @@
 				3E2F656B287FA0E700A27FA9 /* LaunchScreen.storyboard in Resources */,
 				3E2F6568287FA0E700A27FA9 /* Assets.xcassets in Resources */,
 				3E2F6566287FA0E600A27FA9 /* Main.storyboard in Resources */,
+				B52841CB28922D7E004A2204 /* CallCheck.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -421,7 +422,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3WVLC7Y373;
+				DEVELOPMENT_TEAM = Y7G824SH3W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -451,7 +452,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3WVLC7Y373;
+				DEVELOPMENT_TEAM = Y7G824SH3W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TodayAnbu/Sources/Boards/CallCheck.storyboard
+++ b/TodayAnbu/Sources/Boards/CallCheck.storyboard
@@ -1,0 +1,382 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dFI-89-8sy">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--CallCheckViewController-->
+        <scene sceneID="SRi-8n-Vv6">
+            <objects>
+                <viewController title="CallCheckViewController" id="dFI-89-8sy" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rdh-Cs-t13">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bXP-EX-1Ib">
+                                <rect key="frame" x="0.0" y="-6" width="414" height="188.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="통화는 잘 하셨나요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Te8-pE-doN" userLabel="통화는 잘 하셨나요?">
+                                        <rect key="frame" x="112" y="105" width="190" height="29"/>
+                                        <fontDescription key="fontDescription" type="system" weight="black" pointSize="24"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" name="mainIndigo"/>
+                                <constraints>
+                                    <constraint firstItem="Te8-pE-doN" firstAttribute="centerY" secondItem="bXP-EX-1Ib" secondAttribute="centerY" constant="25" id="EOc-g4-Emt"/>
+                                    <constraint firstItem="Te8-pE-doN" firstAttribute="centerX" secondItem="bXP-EX-1Ib" secondAttribute="centerX" id="y3m-fr-3dr"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="통화 후 기록하고 싶으신 내용을 적어주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="Ogc-fG-3gl">
+                                <rect key="frame" x="41" y="241.5" width="332" height="24"/>
+                                <fontDescription key="fontDescription" type="system" weight="black" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oi3-hi-V2r">
+                                <rect key="frame" x="15" y="724" width="384" height="59"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="안부 완료" cornerStyle="medium" buttonSize="large">
+                                    <fontDescription key="titleFontDescription" type="system" weight="black" pointSize="24"/>
+                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="baseBackgroundColor" name="mainIndigo"/>
+                                </buttonConfiguration>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V9y-ei-Hsy">
+                                <rect key="frame" x="15" y="793" width="384" height="59"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="안부 완료"/>
+                                <buttonConfiguration key="configuration" style="gray" title="아니오. 안 받으셨어요." cornerStyle="medium" buttonSize="large">
+                                    <fontDescription key="titleFontDescription" type="system" weight="black" pointSize="24"/>
+                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="baseBackgroundColor" systemColor="systemGray3Color"/>
+                                </buttonConfiguration>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" usesAttributedText="YES" allowsEditingTextAttributes="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5dC-5y-gUR">
+                                <rect key="frame" x="30" y="331.5" width="354" height="280"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="ex) ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="어머니에게">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="최근">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="먹은">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="과일에">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="대해">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="여쭤보았다">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=". ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="어머니가">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="수박을">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="좋아하시는">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="걸">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="알게">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="되어서">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=", ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="여름이">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="가기">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="전에">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="수박을">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="사드려야겠다">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=".">
+                                        <attributes>
+                                            <color key="NSColor" systemColor="placeholderTextColor"/>
+                                            <font key="NSFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="15"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.shadowColor">
+                                        <color key="value" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
+                                        <size key="value" width="3" height="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
+                                        <real key="value" value="0.69999999999999996"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowRadius">
+                                        <integer key="value" value="15"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="9eG-tc-Uwe"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ogc-fG-3gl" firstAttribute="centerY" secondItem="rdh-Cs-t13" secondAttribute="centerY" multiplier="0.566" id="6Mc-ZU-xwQ"/>
+                            <constraint firstItem="Oi3-hi-V2r" firstAttribute="leading" secondItem="9eG-tc-Uwe" secondAttribute="leading" constant="15" id="A29-Q6-FlY"/>
+                            <constraint firstItem="5dC-5y-gUR" firstAttribute="centerX" secondItem="rdh-Cs-t13" secondAttribute="centerX" id="GmX-K9-GjI"/>
+                            <constraint firstItem="V9y-ei-Hsy" firstAttribute="top" secondItem="Oi3-hi-V2r" secondAttribute="bottom" constant="10" id="GrK-Zm-d9N"/>
+                            <constraint firstItem="Ogc-fG-3gl" firstAttribute="centerX" secondItem="rdh-Cs-t13" secondAttribute="centerX" id="UYb-7z-78E"/>
+                            <constraint firstItem="bXP-EX-1Ib" firstAttribute="bottom" secondItem="9eG-tc-Uwe" secondAttribute="centerY" multiplier="0.403" id="WSH-jr-iCm"/>
+                            <constraint firstItem="Oi3-hi-V2r" firstAttribute="centerX" secondItem="rdh-Cs-t13" secondAttribute="centerX" id="Wgv-CB-hrt"/>
+                            <constraint firstItem="V9y-ei-Hsy" firstAttribute="centerX" secondItem="rdh-Cs-t13" secondAttribute="centerX" id="cro-5B-4mw"/>
+                            <constraint firstItem="5dC-5y-gUR" firstAttribute="top" secondItem="rdh-Cs-t13" secondAttribute="centerY" multiplier="0.74" id="h4e-ah-PMC"/>
+                            <constraint firstItem="5dC-5y-gUR" firstAttribute="leading" secondItem="9eG-tc-Uwe" secondAttribute="leading" constant="30" id="lLd-AE-yem"/>
+                            <constraint firstItem="bXP-EX-1Ib" firstAttribute="top" secondItem="9eG-tc-Uwe" secondAttribute="top" constant="-50" id="pcW-as-cn9"/>
+                            <constraint firstItem="Ogc-fG-3gl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9eG-tc-Uwe" secondAttribute="leading" constant="10" id="rlW-xA-n10"/>
+                            <constraint firstItem="5dC-5y-gUR" firstAttribute="bottom" secondItem="rdh-Cs-t13" secondAttribute="centerY" multiplier="1.365" id="tY3-W0-9BO"/>
+                            <constraint firstItem="9eG-tc-Uwe" firstAttribute="trailing" secondItem="bXP-EX-1Ib" secondAttribute="trailing" id="xGg-XL-BLI"/>
+                            <constraint firstItem="bXP-EX-1Ib" firstAttribute="leading" secondItem="9eG-tc-Uwe" secondAttribute="leading" id="xf5-6Z-eil"/>
+                            <constraint firstItem="V9y-ei-Hsy" firstAttribute="leading" secondItem="9eG-tc-Uwe" secondAttribute="leading" constant="15" id="ynn-bf-cWb"/>
+                            <constraint firstItem="9eG-tc-Uwe" firstAttribute="bottom" secondItem="V9y-ei-Hsy" secondAttribute="bottom" constant="10" id="zTM-mx-ZQX"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7eU-AP-wJk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-526" y="296"/>
+        </scene>
+    </scenes>
+    <color key="tintColor" name="mainIndigo"/>
+    <resources>
+        <namedColor name="mainIndigo">
+            <color red="0.15686274509803921" green="0.20000000000000001" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="placeholderTextColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray3Color">
+            <color red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/TodayAnbu/Sources/Boards/CallCheck.storyboard
+++ b/TodayAnbu/Sources/Boards/CallCheck.storyboard
@@ -12,7 +12,7 @@
         <!--CallCheckViewController-->
         <scene sceneID="SRi-8n-Vv6">
             <objects>
-                <viewController title="CallCheckViewController" id="dFI-89-8sy" sceneMemberID="viewController">
+                <viewController title="CallCheckViewController" id="dFI-89-8sy" customClass="CallCheckViewController" customModule="TodayAnbu" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rdh-Cs-t13">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -63,274 +63,12 @@
                                     <color key="baseBackgroundColor" systemColor="systemGray3Color"/>
                                 </buttonConfiguration>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" usesAttributedText="YES" allowsEditingTextAttributes="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5dC-5y-gUR">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" allowsEditingTextAttributes="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5dC-5y-gUR">
                                 <rect key="frame" x="30" y="331.5" width="354" height="280"/>
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                <attributedString key="attributedText">
-                                    <fragment content="ex) ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="어머니에게">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="최근">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="먹은">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="과일에">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="대해">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="여쭤보았다">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=". ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="어머니가">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="수박을">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="좋아하시는">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="걸">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="알게">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="되어서">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=", ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="여름이">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="가기">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="전에">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="수박을">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=" ">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content="사드려야겠다">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" size="17" name=".AppleSDGothicNeoI-Regular"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                    <fragment content=".">
-                                        <attributes>
-                                            <color key="NSColor" systemColor="placeholderTextColor"/>
-                                            <font key="NSFont" metaFont="system" size="17"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                        </attributes>
-                                    </fragment>
-                                </attributedString>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="15"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.shadowColor">
-                                        <color key="value" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="size" keyPath="layer.shadowOffset">
-                                        <size key="value" width="3" height="3"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowOpacity">
-                                        <real key="value" value="0.69999999999999996"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.shadowRadius">
-                                        <integer key="value" value="15"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
+                                <color key="textColor" systemColor="placeholderTextColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                             </textView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="9eG-tc-Uwe"/>
@@ -355,6 +93,11 @@
                             <constraint firstItem="9eG-tc-Uwe" firstAttribute="bottom" secondItem="V9y-ei-Hsy" secondAttribute="bottom" constant="10" id="zTM-mx-ZQX"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="callDoneButton" destination="Oi3-hi-V2r" id="JdM-w2-XG5"/>
+                        <outlet property="callFailButton" destination="V9y-ei-Hsy" id="Aav-fO-Te2"/>
+                        <outlet property="memoView" destination="5dC-5y-gUR" id="Zbr-9s-d0b"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7eU-AP-wJk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
+++ b/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
@@ -8,5 +8,81 @@
 import UIKit
 
 class CallCheckViewController: UIViewController {
-    
+
+    @IBOutlet weak var memoView: UITextView!
+    @IBOutlet weak var callDoneButton: UIButton!
+    @IBOutlet weak var callFailButton: UIButton!
+    private let placeholder = "ex) 어머니에게 최근 먹은 과일에 대해 여쭤보았다. 어머니가 수박을 좋아하시는 걸 알게 되어서, 여름이 가기 전에 수박을 사드려야겠다."
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTextView()
+        configureButtons()
+    }
+}
+
+extension CallCheckViewController {
+    func configureTextView() {
+        memoView.font = .systemFont(ofSize: 16.0, weight: .regular)
+        memoView.text = placeholder
+        memoView.textColor = .placeholderText
+        memoView.textContainerInset = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        memoView.layer.shadowColor = UIColor.systemGray.cgColor
+        memoView.layer.shadowOffset = CGSize(width: 0, height: 4)
+        memoView.layer.shadowRadius = 5
+        memoView.layer.shadowOpacity = 1
+        memoView.layer.masksToBounds = false
+        memoView.layer.cornerRadius = 20
+        memoView.delegate = self
+    }
+    func configureButtons() {
+        callDoneButton.addTarget(self, action: #selector(onTapDoneButton), for: .touchUpInside)
+        callFailButton.addTarget(self, action: #selector(onTapFailButton), for: .touchUpInside)
+    }
+    @objc func onTapDoneButton() {
+        appendMemos()
+    }
+
+    @objc func onTapFailButton() {
+    }
+
+    func appendMemos() {
+        // Date Int format ex) 220729003621
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko")
+        dateFormatter.dateFormat = "yyMMddHHmmss"
+        let now = dateFormatter.string(from: Date())
+
+        // Date LocalizedString format ex) 2022년 7월. 29일, 오전 12:47
+//        let now = Date()
+//        let timeText = now.formatted(date: .omitted, time: .shortened)
+//        let dateText = now.formatted(.dateTime.year().month(.abbreviated).day())
+//        let dateAndTimeFormat = NSLocalizedString("%@, %@", comment: "Date and time format string")
+        var memos: [String: String] = UserDefaults.standard.dictionary(forKey: "memos") as? [String: String] ?? [:]
+        if !memos.isEmpty {
+            UserDefaults.standard.removeObject(forKey: "memos")
+        }
+        memos[now] = memoView.text!
+        UserDefaults.standard.set(memos, forKey: "memos")
+    }
+}
+
+extension CallCheckViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        guard textView.textColor == .placeholderText else { return }
+        textView.textColor = .label
+        textView.text = nil
+    }
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = "텍스트 입력"
+            textView.textColor = .placeholderText
+        }
+    }
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            textView.resignFirstResponder()
+        }
+        return true
+    }
 }

--- a/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
+++ b/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
@@ -1,0 +1,12 @@
+//
+//  CallCheckViewController.swift
+//  TodayAnbu
+//
+//  Created by taekkim on 2022/07/28.
+//
+
+import UIKit
+
+class CallCheckViewController: UIViewController {
+    
+}

--- a/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
+++ b/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
@@ -49,17 +49,8 @@ extension CallCheckViewController {
     }
 
     func appendMemos() {
-        // Date Int format ex) 220729003621
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "ko")
-        dateFormatter.dateFormat = "yyMMddHHmmss"
-        let now = dateFormatter.string(from: Date())
+        let now = Date.currentNumericLocalizedDateTime
 
-        // Date LocalizedString format ex) 2022년 7월. 29일, 오전 12:47
-//        let now = Date()
-//        let timeText = now.formatted(date: .omitted, time: .shortened)
-//        let dateText = now.formatted(.dateTime.year().month(.abbreviated).day())
-//        let dateAndTimeFormat = NSLocalizedString("%@, %@", comment: "Date and time format string")
         var memos: [String: String] = UserDefaults.standard.dictionary(forKey: "memos") as? [String: String] ?? [:]
         if !memos.isEmpty {
             UserDefaults.standard.removeObject(forKey: "memos")

--- a/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
+++ b/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
@@ -14,6 +14,7 @@ class CallCheckViewController: UIViewController {
     @IBOutlet weak var callFailButton: UIButton!
     private let placeholder = "ex) 어머니에게 최근 먹은 과일에 대해 여쭤보았다. 어머니가 수박을 좋아하시는 걸 알게 되어서, 여름이 가기 전에 수박을 사드려야겠다."
 
+    // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTextView()
@@ -21,6 +22,7 @@ class CallCheckViewController: UIViewController {
     }
 }
 
+// MARK: - Functions
 extension CallCheckViewController {
     func configureTextView() {
         memoView.font = .systemFont(ofSize: 16.0, weight: .regular)
@@ -67,6 +69,7 @@ extension CallCheckViewController {
     }
 }
 
+// MARK: - Delegate
 extension CallCheckViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         guard textView.textColor == .placeholderText else { return }

--- a/TodayAnbu/Sources/Extensions/DateFormatting.swift
+++ b/TodayAnbu/Sources/Extensions/DateFormatting.swift
@@ -7,6 +7,21 @@
 import Foundation
 
 extension Date {
+    static var currentNumericLocalizedDateTime: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko")
+        dateFormatter.dateFormat = "yyMMddHHmmss" // 202207032314 (KST)
+        return dateFormatter.string(from: Date())
+    }
+
+    static var currentNaturalLocalizedDatetTime: String {
+        let now = Date()
+        let dateText = now.formatted(.dateTime.year().month(.abbreviated).day())
+        let timeText = now.formatted(date: .omitted, time: .shortened)
+        let dateAndTimeFormat = NSLocalizedString("%@, %@", comment: "Date and time format string") // 2022년 7월. 29일, 오전 12:47
+        return String(format: dateAndTimeFormat, dateText, timeText)
+    }
+
     func toString() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH:mm" // 2022-07-03 23:14


### PR DESCRIPTION
## 개요
Call Check View를 만들었습니다.

<br/>

## 작업사항
### 작업 사항
- [x] UI 구현
- [x] TextView placeholder 구현
- [x] TextView shadow
- [x] TextView Done 버튼 커스텀
- [x] 현재시각과 메모내용 Userdefault에 dictionary로 각각 key, value로 저장

### References
무수히 많음

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)
[ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
이미지 이쁘게 넣는 코드를 아래 두니 참고해서 작성
](https://user-images.githubusercontent.com/59143479/181589124-ca91f2c5-5d50-4fa4-8f44-b5d483ccda6f.mp4
)

## 그외
### 리뷰 포인트
ex) 리뷰받고 싶은 내용, 고민한 내용  등에 대해 적어주세요
- 루미의 centerY 에서 multiplier 로 autolayout을 잡는 방법을 사용했습니다.
- textview의 placeholder와 shawdow를 만드는 부분에서 커스텀 코드가 있습니다
- 메모한 시각을 key로 메모 내용을 value로 userdefault 상의 딕셔너리로 저장합니다

### 진행 예정 사항
ex) 작업 진행 예정사항 및 개선하고 싶은 내용이 있다면 추가 해주세요
- [ ] 버튼들 navigating

Closed #70 #89