### PR TITLE
Fix/96 modal dismiss action

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,14 +9,13 @@ disabled_rules:
 #
 #    # 강제 언래핑은 피해야합니다. https://realm.github.io/SwiftLint/force_unwrapping.html
 #   - force_unwrapping
-
     - unused_optional_binding
     - line_length
     - todo
     - file_length
     - function_body_length
     - type_body_length
-    - trailing_whitespace
+
 # Default가 비활성화인 규칙을 활성화시키기
 opt_in_rules:
     # .count==0 보다는 .isEmpty를 사용하는 것이 좋습니다. https://realm.github.io/SwiftLint/empty_count.html

--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -35,12 +35,9 @@
 		A9332C77288E908F001A1B76 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9332C76288E908F001A1B76 /* DateFormatting.swift */; };
 		A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A9128868F7100530B51 /* NotificationModalViewController.swift */; };
 		A9B32A94288691EA00530B51 /* NotificationTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A93288691EA00530B51 /* NotificationTime.swift */; };
-
 		A9CF7E652892D22700189E8B /* CallModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CF7E642892D22700189E8B /* CallModelData.swift */; };
-
 		B52841CB28922D7E004A2204 /* CallCheck.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B52841CA28922D7E004A2204 /* CallCheck.storyboard */; };
 		B52841D128926DA7004A2204 /* CallCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52841D028926DA7004A2204 /* CallCheckViewController.swift */; };
-
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -167,12 +164,9 @@
 				7B2E9C6D288429B8006BE5C8 /* SettingPersonalDataCell.swift */,
 				7B2E9C6F2884397B006BE5C8 /* SettingHeaderView.swift */,
 				A9B32A93288691EA00530B51 /* NotificationTime.swift */,
-
 				A9CF7E642892D22700189E8B /* CallModelData.swift */,
-
 				7B2216752891452D00B14C5C /* MemoData.swift */,
 				7B2216772891493500B14C5C /* MemoCell.swift */,
-
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -320,7 +314,7 @@
 				3ED6D20A289280B8008F1D93 /* DadInitViewController.swift in Sources */,
 				A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */,
 				3E2F6561287FA0E600A27FA9 /* SceneDelegate.swift in Sources */,
-				3EC0D9CB28801E9F00A98E73 /* UserInitViewController.swift in Sources */,
+				3EC0D9CB28801E9F00A98E73 /* MomInitViewController.swift in Sources */,
 				A9CF7E652892D22700189E8B /* CallModelData.swift in Sources */,
 				3EC0D9CB28801E9F00A98E73 /* MomInitViewController.swift in Sources */,
 				3EC0D9CD2880FAD500A98E73 /* UITextfieldExtension.swift in Sources */,
@@ -473,7 +467,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Y7G824SH3W;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -503,7 +497,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = Y7G824SH3W;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TodayAnbu/Resources/Assets.xcassets/Colors/activePinkColor.colorset/Contents.json
+++ b/TodayAnbu/Resources/Assets.xcassets/Colors/activePinkColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7C",
+          "green" : "0x7C",
+          "red" : "0xF1"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
+++ b/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
@@ -276,7 +276,6 @@
                                     <action selector="nextButtonAction:" destination="NtZ-78-jYv" eventType="touchUpInside" id="qGZ-9G-edS"/>
                                     <action selector="setNotificationTime:" destination="4Mc-d9-Cdu" eventType="touchUpInside" id="o92-Kk-wcb"/>
                                     <action selector="startButttonAction:" destination="4Mc-d9-Cdu" eventType="touchUpInside" id="Nlf-hM-MQL"/>
-
                                     <segue destination="h9C-xi-h1l" kind="show" id="qjY-Is-6iQ"/>
                                 </connections>
                             </button>
@@ -418,7 +417,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iG4-SX-mUD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2367" y="-450"/>
+            <point key="canvasLocation" x="2367" y="-582"/>
         </scene>
         <!--Dad Init View Controller-->
         <scene sceneID="NSE-tY-5Hw">
@@ -523,7 +522,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="7fl-9i-khf"/>
+        <segue reference="tef-Cz-cHx"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
     <resources>

--- a/TodayAnbu/Sources/Controllers/AboutUsViewController.swift
+++ b/TodayAnbu/Sources/Controllers/AboutUsViewController.swift
@@ -61,5 +61,4 @@ class AboutUsViewController: UIViewController {
         userURL = "https://github.com/cozytk"
         sendURL(url: userURL)
     }
-    
 }

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -267,8 +267,8 @@ extension DadInitViewController {
 
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {
-                let title = "부모님께 전화안한지 10일!"
-                let message = "오늘,안부의 알람입니다."
+                let title = "아버지에게 안부 전화드려보세요!"
+                let message = "오늘의 토픽 주제로 이야기해봐요!"
 
                 if settings.authorizationStatus == .authorized {
                     let content = UNMutableNotificationContent()
@@ -289,7 +289,7 @@ extension DadInitViewController {
                             dateComponent.weekday = weekDay
 
                             let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
-                            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+                            let request = UNNotificationRequest(identifier:UUID().uuidString, content: content, trigger: trigger)
                             self.notificationCenter.add(request) { error in
                                 if error != nil {
                                     print("Error " + error.debugDescription)
@@ -301,12 +301,16 @@ extension DadInitViewController {
                         }
                     } else {
                         let notificationAlert = UIAlertController(title: "알람을 설정하지 않으셨나요?", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
-                        notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
+                        notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                            self.dismiss(animated: true)
+                        }))
                         self.present(notificationAlert, animated: true)
                     }
 
                     let notificationAlert = UIAlertController(title: "알람 설정완료!", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
-                    notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
+                    notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                        self.dismiss(animated: true)
+                    }))
                     self.present(notificationAlert, animated: true)
 
                     // notification 허용하지 않을 경우
@@ -321,13 +325,13 @@ extension DadInitViewController {
                         }
                     }
                     alertController.addAction(goToSettings)
-                    alertController.addAction(UIAlertAction(title: "취소", style: .default, handler: { (_) in }))
+                    alertController.addAction(UIAlertAction(title: "취소", style: .default, handler: { (_) in
+                        self.dismiss(animated: true)
+                    }))
                     self.present(alertController, animated: true)
                 }
             }
         }
-
-        self.dismiss(animated: true)
     }
 }
 

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -205,7 +205,7 @@ extension DadInitViewController {
 
             notificationButton.buttonStack.addArrangedSubview(firstLabel)
             notificationButton.buttonStack.tag = index
-            notificationButton.buttonStack.backgroundColor = .dadDeepSkyblue
+            notificationButton.buttonStack.backgroundColor = .systemGray3
             notificationButton.buttonStack.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(setIndex(_:))))
 
             notificationButtonList.append(notificationButton)
@@ -251,7 +251,7 @@ extension DadInitViewController {
         if notificationButtonList[buttonIndex].isSelected {
             notificationButtonList[buttonIndex].buttonStack.backgroundColor = .dadLightSkyblue
         } else {
-            notificationButtonList[buttonIndex].buttonStack.backgroundColor = .dadDeepSkyblue
+            notificationButtonList[buttonIndex].buttonStack.backgroundColor = .systemGray3
         }
     }
 }
@@ -326,6 +326,8 @@ extension DadInitViewController {
                 }
             }
         }
+
+        self.dismiss(animated: true)
     }
 }
 

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -289,7 +289,7 @@ extension DadInitViewController {
                             dateComponent.weekday = weekDay
 
                             let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
-                            let request = UNNotificationRequest(identifier:UUID().uuidString, content: content, trigger: trigger)
+                            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
                             self.notificationCenter.add(request) { error in
                                 if error != nil {
                                     print("Error " + error.debugDescription)

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -163,7 +163,7 @@ class MainViewController: UIViewController {
 
             self.goCallApp(url: "tel://" + (UserDefaults.standard.string(forKey: "momPhoneNumber") ?? ""))
         }
-        
+
         let dadCall = UIAlertAction(title: "아빠한테 전화하기", style: .default) { _ in
             CallManager.shared.data.isDadCall.toggle()
             self.goCallApp(url: "tel://" + (UserDefaults.standard.string(forKey: "dadPhoneNumber") ?? ""))

--- a/TodayAnbu/Sources/Controllers/MemoViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MemoViewController.swift
@@ -14,12 +14,12 @@ class MemoViewController: UIViewController {
     enum Section {
         case main
     }
-    
+
     var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
     var list: [MemoData] = MemoData.list
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // MARK: - presentation
         dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MemoCell", for: indexPath) as? MemoCell else {
@@ -35,7 +35,7 @@ class MemoViewController: UIViewController {
         snapshot.appendSections([.main])
         snapshot.appendItems(list, toSection: .main)
         dataSource.apply(snapshot)
-        
+
         // MARK: - layer
         collectionView.collectionViewLayout = layout()
     }

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -268,8 +268,8 @@ extension MomInitViewController {
         
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {
-                let title = "부모님께 전화안한지 10일!"
-                let message = "오늘,안부의 알람입니다."
+                let title = "어머니에게 안부 전화드려보세요!"
+                let message = "오늘의 토픽 주제로 이야기해봐요!"
                 
                 if settings.authorizationStatus == .authorized {
                     let content = UNMutableNotificationContent()
@@ -290,7 +290,7 @@ extension MomInitViewController {
                             dateComponent.weekday = weekDay
                             
                             let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
-                            let request = UNNotificationRequest(identifier: "firstSetting", content: content, trigger: trigger)
+                            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
                             self.notificationCenter.add(request) { error in
                                 if error != nil {
                                     print("Error " + error.debugDescription)
@@ -302,12 +302,16 @@ extension MomInitViewController {
                         }
                     } else {
                         let notificationAlert = UIAlertController(title: "알람을 설정하지 않으셨나요?", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
-                        notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
+                        notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                            self.dismiss(animated: true)
+                        }))
                         self.present(notificationAlert, animated: true)
                     }
                     
                     let notificationAlert = UIAlertController(title: "알람 설정완료!", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
-                    notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
+                    notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                        self.dismiss(animated: true)
+                    }))
                     self.present(notificationAlert, animated: true)
                     
                     // notification 허용하지 않을 경우
@@ -322,12 +326,13 @@ extension MomInitViewController {
                         }
                     }
                     alertController.addAction(goToSettings)
-                    alertController.addAction(UIAlertAction(title: "취소", style: .default, handler: { (_) in }))
+                    alertController.addAction(UIAlertAction(title: "취소", style: .default, handler: { (_) in
+                        self.dismiss(animated: true)
+                    }))
                     self.present(alertController, animated: true)
                 }
             }
         }
-        self.dismiss(animated: true)
     }
 }
 

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -37,7 +37,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         let dot = UILabel()
         dot.text = "."
         dot.font = .boldSystemFont(ofSize: 30)
-        dot.textColor = .mainIndigo
+        dot.textColor = .activePinkColor
         return dot
     }()
     
@@ -206,7 +206,7 @@ extension MomInitViewController {
             
             notificationButton.buttonStack.addArrangedSubview(firstLabel)
             notificationButton.buttonStack.tag = index
-            notificationButton.buttonStack.backgroundColor = .dadDeepSkyblue
+            notificationButton.buttonStack.backgroundColor = .systemGray3
             notificationButton.buttonStack.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(setIndex(_:))))
             
             notificationButtonList.append(notificationButton)
@@ -252,7 +252,7 @@ extension MomInitViewController {
         if notificationButtonList[buttonIndex].isSelected {
             notificationButtonList[buttonIndex].buttonStack.backgroundColor = .momLightPink
         } else {
-            notificationButtonList[buttonIndex].buttonStack.backgroundColor = .dadDeepSkyblue
+            notificationButtonList[buttonIndex].buttonStack.backgroundColor = .systemGray3
         }
     }
 }
@@ -327,6 +327,7 @@ extension MomInitViewController {
                 }
             }
         }
+        self.dismiss(animated: true)
     }
 }
 

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -15,7 +15,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var momNumberTextfield: UITextField!
     @IBOutlet weak var startButton: UIButton!
     @IBOutlet weak var timePicker: UIDatePicker!
-    
+
     private let notificationCenter = UNUserNotificationCenter.current()
     private var notificationGuideText: UILabel = {
         let label = UILabel()
@@ -23,7 +23,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         label.font = UIFont.systemFont(ofSize: 14, weight: .regular)
         return label
     }()
-    
+
     private var notificationButtonList: [NotificationButton] = []
     private let horizontalStack = UIStackView()
     private let notificationTimeSettingText: UILabel = {
@@ -40,7 +40,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         dot.textColor = .activePinkColor
         return dot
     }()
-    
+
     // 버튼을 탭했을때, 탭한 버튼에 나타나는 변화들
     private var buttonIndex: Int = 0 {
 
@@ -59,12 +59,12 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
             }
         }
     }
-    
+
     // 데이트 피커를 움직였을 때 나타나는 변화
     lazy private var timeLabel = timePicker.date {
         didSet {
             notificationButtonList[buttonIndex].notificationTime = timeLabel
-            
+
             if timeLabel.toString().isEmpty {
                 addNotificationTimeLabel(indexPath: buttonIndex, time: timeLabel.toString())
             } else {
@@ -73,10 +73,10 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
             }
         }
     }
-    
+
     // UserDefault 세팅용
     private var momPhoneNumber: String? = ""
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -85,20 +85,20 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         momNumberTextfield.delegate = self
         momNumberTextfield.setBottomBorder(color: UIColor.systemGray4)
         momNumberTextfield.addDoneButtonOnKeyboard()
-        
+
         momDayVstack.isHidden = true
         startButton.isEnabled = false
         startButton.layer.cornerRadius = 10
-        
+
         // 7개 알람 버튼 레이아웃 설정
         setHStackViewDefaultConstraints()
         makeNotificationButtonList()
         addSubViewNotificationButton()
         initializeButtonSize(size: 15)
-        
+
         // time picker 설정
         timePicker.isHidden = true
-        
+
         // notification 접근 허가 설정
         notificationCenter.requestAuthorization(options: [.alert, .sound]) { (permissionGranted, error) in
             if !permissionGranted {
@@ -108,7 +108,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         }
 //        self.navigationItem.setHidesBackButton(true, animated: true)
     }
-    
+
     @IBAction func startButttonAction(_ sender: Any) {
         UserDefaults.standard.set(true, forKey: "isFisrtLogin") // 최초 로그인인지 확인
         if momNumberTextfield.hasValidPhoneNumber {
@@ -119,7 +119,6 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         timeLabel = sender.date
         print("이 값은 데이트 피커의 date 값입니다. \(sender.date)") // Test
     }
-    
 }
 
 extension MomInitViewController {
@@ -131,37 +130,37 @@ extension MomInitViewController {
             notificationTimeSettingText.topAnchor.constraint(equalTo: momDayVstack.topAnchor, constant: 10),
             notificationTimeSettingText.leftAnchor.constraint(equalTo: momDayVstack.leftAnchor, constant: 5)
         ])
-        
+
         momDayVstack.addSubview(notificationGuideText)
         notificationGuideText.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             notificationGuideText.topAnchor.constraint(equalTo: notificationTimeSettingText.topAnchor, constant: 35),
             notificationGuideText.leftAnchor.constraint(equalTo: momDayVstack.leftAnchor, constant: 5)
         ])
-        
+
         momDayVstack.addSubview(horizontalStack)
         horizontalStack.axis = .horizontal
         horizontalStack.alignment = .top
         horizontalStack.distribution = .equalSpacing
         horizontalStack.spacing = 5
         horizontalStack.translatesAutoresizingMaskIntoConstraints = false
-        
+
         NSLayoutConstraint.activate([
             horizontalStack.topAnchor.constraint(equalTo: notificationTimeSettingText.topAnchor, constant: 75),
             horizontalStack.centerXAnchor.constraint(equalTo: momDayVstack.centerXAnchor)
         ])
     }
-    
+
     private func initializeButtonSize(size: CGFloat) {
         for button in notificationButtonList {
             button.buttonStack.directionalLayoutMargins =  NSDirectionalEdgeInsets(top: size, leading: size, bottom: size, trailing: size)
         }
     }
-    
+
     private func removeTimeLabel() {
         notificationButtonList[buttonIndex].buttonStack.arrangedSubviews[1].removeFromSuperview()
     }
-    
+
     // 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
     private func addNotificationTimeLabel(indexPath: Int, time: String) {
         let timeLabel: UILabel = {
@@ -171,11 +170,11 @@ extension MomInitViewController {
             label.textColor = .white
             return label
         }()
-        
+
         if notificationButtonList[indexPath].buttonStack.subviews.count != 2 {
             notificationButtonList[indexPath].buttonStack.addArrangedSubview(timeLabel)
             notificationButtonList[indexPath].buttonStack.directionalLayoutMargins =  NSDirectionalEdgeInsets(top: 10, leading: 5, bottom: 10, trailing: 5)
-            
+
             // 알람 세팅된 버튼을 다시 클릭했을 경우
         } else if notificationButtonList[indexPath].isSelected && notificationButtonList[indexPath].buttonStack.subviews.count == 2 {
             notificationButtonList[indexPath].buttonStack.subviews[1].removeFromSuperview()
@@ -195,7 +194,7 @@ extension MomInitViewController {
             dayButton.isLayoutMarginsRelativeArrangement = true
             dayButton.translatesAutoresizingMaskIntoConstraints = false
             let notificationButton = NotificationButton(id: index, buttonStack: dayButton, isSelected: false, notificationTime: Date())
-            
+
             let firstLabel: UILabel = {
                 let label = UILabel()
                 label.text = WeekDay.allCases[index].rawValue
@@ -203,16 +202,16 @@ extension MomInitViewController {
                 label.textColor = .white
                 return label
             }()
-            
+
             notificationButton.buttonStack.addArrangedSubview(firstLabel)
             notificationButton.buttonStack.tag = index
             notificationButton.buttonStack.backgroundColor = .systemGray3
             notificationButton.buttonStack.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(setIndex(_:))))
-            
+
             notificationButtonList.append(notificationButton)
         }
     }
-    
+
     private func addSubViewNotificationButton() {
         for button in notificationButtonList {
             let vStack: UIStackView = {
@@ -222,7 +221,7 @@ extension MomInitViewController {
                 stack.spacing = -16
                 return stack
             }()
-            
+
             vStack.addArrangedSubview(button.buttonStack)
             horizontalStack.addArrangedSubview(vStack)
         }
@@ -265,20 +264,19 @@ extension MomInitViewController {
             dateList.append(button.notificationTime)
             dayList.append(button.indexPath)
         }
-        
+
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {
                 let title = "어머니에게 안부 전화드려보세요!"
                 let message = "오늘의 토픽 주제로 이야기해봐요!"
-                
+
                 if settings.authorizationStatus == .authorized {
                     let content = UNMutableNotificationContent()
                     content.title = title
                     content.body = message
-                    
+
                     if dayList.isEmpty == false {
                         for index in 0...dayList.count-1 {
-                            
                             var dateComponent = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: dateList[index])
                             let weekDay: Int = {
                                 var weekDay = dayList[index] + 2
@@ -288,7 +286,6 @@ extension MomInitViewController {
                                 return weekDay
                             }()
                             dateComponent.weekday = weekDay
-                            
                             let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
                             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
                             self.notificationCenter.add(request) { error in
@@ -307,13 +304,13 @@ extension MomInitViewController {
                         }))
                         self.present(notificationAlert, animated: true)
                     }
-                    
+
                     let notificationAlert = UIAlertController(title: "알람 설정완료!", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
                     notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
                         self.dismiss(animated: true)
                     }))
                     self.present(notificationAlert, animated: true)
-                    
+
                     // notification 허용하지 않을 경우
                 } else {
                     let alertController = UIAlertController(title: "알림을 설정하시겠어요?", message: "설정에서 알람 허용을 해주셔야해요!", preferredStyle: .alert)
@@ -344,7 +341,7 @@ extension MomInitViewController {
         } else {
             textField.setBottomBorder(color: UIColor.red)
         }
-        
+
         if textField.text!.count < 12 {
             if textField == momNumberTextfield {
                 momDayVstack.isHidden = true
@@ -353,7 +350,7 @@ extension MomInitViewController {
         let validation = textField.text!.count + string.count - range.length
         return !(validation > 11)
     }
-    
+
     // textfield keyboard가 내려가면 호출
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField == momNumberTextfield {
@@ -368,7 +365,7 @@ extension MomInitViewController {
                 startButton.isEnabled = false
                 startButton.backgroundColor = UIColor.systemGray4
                 momDayVstack.isHidden = true
-                
+
             }
         }
     }

--- a/TodayAnbu/Sources/Controllers/NotificationModalViewController.swift
+++ b/TodayAnbu/Sources/Controllers/NotificationModalViewController.swift
@@ -95,7 +95,7 @@ class NotificationModalViewController: UIViewController {
             }
         }
     }
-    
+
     func formattedDate(date: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "d MMM y HH:mm"

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -34,7 +34,7 @@ class SettingViewController: UIViewController {
         super.viewDidLoad()
         configureViewComponent()
     }
-    
+
     func configureViewComponent() {
         view.addSubview(tableView)
         view.addSubview(settingTopArea)
@@ -65,9 +65,9 @@ class SettingViewController: UIViewController {
         }
 //        let state = switchOnAndOff.isOn ? "On" : "Off"
 //        print(state)
-        
+
     }
-    
+
     func removeLocalNotifications() {
         if #available(iOS 10.0, *) {
             UNUserNotificationCenter.current().getPendingNotificationRequests(completionHandler: { requests -> Void in
@@ -95,7 +95,7 @@ class SettingViewController: UIViewController {
             }
         }
     }
-    
+
 }
 
 extension SettingViewController: UITableViewDataSource {

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -71,10 +71,10 @@ class SettingViewController: UIViewController {
     func removeLocalNotifications() {
         if #available(iOS 10.0, *) {
             UNUserNotificationCenter.current().getPendingNotificationRequests(completionHandler: { requests -> Void in
-                print("\(requests.count) requests -------")
+                print("현재 설정된 request의 개수 \(requests.count)")
                 for request in requests {
                     let notifIdentifier: String = request.identifier as String
-                    print("notifIdentifier deleted: \(notifIdentifier)")
+                    print("삭제될 request: \(notifIdentifier)")
                     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [notifIdentifier])
                 }
             })

--- a/TodayAnbu/Sources/Extensions/UIColor+Extension.swift
+++ b/TodayAnbu/Sources/Extensions/UIColor+Extension.swift
@@ -22,4 +22,5 @@ extension UIColor {
     static let dadGaugeDeep = UIColor(named: "dadGaugeDeep")
     static let mainTitleOrange = UIColor(named: "mainTitleOrange")
     static let mainTitleFontColor = UIColor(named: "mainTitleFontColor")
+    static let activePinkColor = UIColor(named: "activePinkColor")
 }

--- a/TodayAnbu/Sources/Models/MemoCell.swift
+++ b/TodayAnbu/Sources/Models/MemoCell.swift
@@ -10,7 +10,6 @@ import UIKit
 class MemoCell: UICollectionViewCell {
     @IBOutlet weak var dayLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
-    
     override func awakeFromNib() {
         super.awakeFromNib()
         // descriptionLabel.sizeToFit()

--- a/TodayAnbu/Sources/SceneDelegate.swift
+++ b/TodayAnbu/Sources/SceneDelegate.swift
@@ -15,7 +15,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
-        
         // MARK: 개발 생산성을 위해 엔트리 포인트를 고정하고자 하는 경우 아래의 코드에서 rootViewController를 지정하여 사용
         /*
         guard let scene = (scene as? UIWindowScene) else { return }


### PR DESCRIPTION
## 개요
1. 알람 설정 창에서 알람 설정 완료 버튼시, 완료 alert추가
2. 알람을 설정하지 않은 경우, 설정창에서 다시 설정할 수 있다는 alert message 추가
3. 알람 관련 코드 일부 수정 (NotificationCenter에 알람 요청할 때, UUID를 사용해서 식별할 수 있게 다시 고침)
4. 알람 설정 버튼 관련 코드 일부 수정 ( 알람 버튼 비활성화 색상을 systemGray3로 통일 및 dot 색상 수정)

## 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)
<p align="left">
  <img width="200" alt="화면1" src="https://user-images.githubusercontent.com/103009135/182012296-7b81b0f1-3166-4304-b186-a35c5b3f8d84.png">
  <img width="200" alt="화면2" src="https://user-images.githubusercontent.com/103009135/182012337-c997c8a6-c3dd-477f-a2ce-0024b7b79a22.png">
</p>

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/103009135/182012369-d9b8cfb8-ba6d-411c-99ae-3ec9fe5cb54e.png">



## 추후 작업 진행 
1. Userdefault에 맨 처음 알람 설정 정보 저장해야함
2. 저장된 정보를 바탕으로 설정창에서 알람 toggle시, userdefault에 저장된 정보로 notificationCenter에 request 날려야함 
