### PR TITLE
Fix/onboarding layout [ #103 ]

### DIFF
--- a/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
+++ b/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
@@ -56,14 +56,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 대표적인 증상으로 무기력함과 우울감이 있어요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TyM-vL-RDw">
-                                <rect key="frame" x="65" y="763" width="284" height="18"/>
+                                <rect key="frame" x="65" y="725" width="284" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IY4-tW-qWX">
-                                <rect key="frame" x="20" y="822.5" width="52" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IY4-tW-qWX">
+                                <rect key="frame" x="36" y="822.5" width="52" height="31"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Skip"/>
@@ -71,9 +70,8 @@
                                     <segue destination="NtZ-78-jYv" kind="show" id="7fl-9i-khf"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="szI-PR-2gr">
-                                <rect key="frame" x="340" y="822.5" width="54" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="szI-PR-2gr">
+                                <rect key="frame" x="325" y="822.5" width="54" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Next"/>
                                 <connections>
@@ -83,8 +81,8 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dadPicture" translatesAutoresizingMaskIntoConstraints="NO" id="Ab0-3b-621">
                                 <rect key="frame" x="40" y="70.5" width="334" height="584"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="갱년기는 급격한 호르몬 변화를 겪는 시기로" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDk-mg-it6">
-                                <rect key="frame" x="120" y="701" width="253.5" height="18"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="갱년기는 급격한 호르몬 변화를 겪는 시기로" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDk-mg-it6">
+                                <rect key="frame" x="80.5" y="702" width="253.5" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -94,13 +92,17 @@
                         <color key="backgroundColor" name="dadDeepSkyblue"/>
                         <constraints>
                             <constraint firstItem="Ab0-3b-621" firstAttribute="leading" secondItem="OvF-j1-dXT" secondAttribute="leading" constant="40" id="0jd-aX-L3e"/>
-                            <constraint firstItem="TyM-vL-RDw" firstAttribute="top" secondItem="MDk-mg-it6" secondAttribute="bottom" constant="43" id="98o-Hs-SI0"/>
+                            <constraint firstItem="TyM-vL-RDw" firstAttribute="top" secondItem="MDk-mg-it6" secondAttribute="bottom" constant="5" id="98o-Hs-SI0"/>
                             <constraint firstItem="TyM-vL-RDw" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="9I6-09-4yO"/>
+                            <constraint firstItem="IY4-tW-qWX" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" multiplier="0.3" id="Nmd-EZ-cUR"/>
                             <constraint firstItem="MDk-mg-it6" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="PYA-vN-hk3"/>
                             <constraint firstItem="1eV-IS-3iG" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="Sec-at-YbP"/>
                             <constraint firstItem="rmL-0a-M5c" firstAttribute="bottom" secondItem="1eV-IS-3iG" secondAttribute="bottom" constant="180" id="a0U-8u-1iw"/>
+                            <constraint firstItem="IY4-tW-qWX" firstAttribute="centerY" secondItem="rmL-0a-M5c" secondAttribute="centerY" multiplier="1.85" id="bAT-cK-7FK"/>
                             <constraint firstItem="MDk-mg-it6" firstAttribute="top" secondItem="1eV-IS-3iG" secondAttribute="bottom" constant="20" id="esP-Ty-7Eh"/>
+                            <constraint firstItem="szI-PR-2gr" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" multiplier="1.7" id="lMl-53-Aww"/>
                             <constraint firstItem="Ab0-3b-621" firstAttribute="centerY" secondItem="rmL-0a-M5c" secondAttribute="centerY" multiplier="0.8" id="oVi-sp-lgE"/>
+                            <constraint firstItem="szI-PR-2gr" firstAttribute="centerY" secondItem="rmL-0a-M5c" secondAttribute="centerY" multiplier="1.85" id="r74-KI-40d"/>
                             <constraint firstItem="Ab0-3b-621" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="wW5-RL-HFW"/>
                         </constraints>
                     </view>
@@ -134,13 +136,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완화에 도움이 된다고 해요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ycP-kV-iHe">
-                                <rect key="frame" x="127" y="728" width="160" height="18"/>
+                                <rect key="frame" x="127" y="725" width="160" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L7O-UY-DRG">
-                                <rect key="frame" x="20" y="822.5" width="94" height="31"/>
+                                <rect key="frame" x="36" y="822.5" width="52" height="31"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Skip"/>
@@ -149,7 +151,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g3a-fE-OqV">
-                                <rect key="frame" x="300" y="822.5" width="94" height="31"/>
+                                <rect key="frame" x="325" y="822.5" width="54" height="31"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Next"/>
                                 <connections>
@@ -160,22 +162,19 @@
                         <viewLayoutGuide key="safeArea" id="Jhx-1G-qFV"/>
                         <color key="backgroundColor" red="0.94901961089999998" green="0.95686274770000002" blue="0.96470588450000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="Jhx-1G-qFV" firstAttribute="trailing" secondItem="L7O-UY-DRG" secondAttribute="trailing" constant="300" id="297-xU-MpK"/>
                             <constraint firstItem="g3a-fE-OqV" firstAttribute="centerY" secondItem="Jhx-1G-qFV" secondAttribute="centerY" multiplier="1.85" id="GK0-Zx-Cn6"/>
-                            <constraint firstItem="L7O-UY-DRG" firstAttribute="leading" secondItem="Jhx-1G-qFV" secondAttribute="leading" constant="20" id="HZZ-TC-AoP"/>
-                            <constraint firstItem="Jhx-1G-qFV" firstAttribute="trailing" secondItem="g3a-fE-OqV" secondAttribute="trailing" constant="20" id="Hbf-P6-o0M"/>
                             <constraint firstItem="ycP-kV-iHe" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" id="L2a-Am-fnT"/>
                             <constraint firstItem="7nc-8V-HKl" firstAttribute="centerY" secondItem="Jhx-1G-qFV" secondAttribute="centerY" multiplier="0.8" id="PWh-aw-64r"/>
                             <constraint firstItem="3HO-e8-lu3" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" id="TD6-gv-bqS"/>
-                            <constraint firstItem="g3a-fE-OqV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="L7O-UY-DRG" secondAttribute="trailing" constant="8" symbolic="YES" id="WGZ-9r-nq1"/>
+                            <constraint firstItem="L7O-UY-DRG" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" multiplier="0.3" id="TPv-vY-RKb"/>
                             <constraint firstItem="Y5B-ds-Wwi" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" id="XnH-mX-gam"/>
                             <constraint firstItem="L7O-UY-DRG" firstAttribute="centerY" secondItem="Jhx-1G-qFV" secondAttribute="centerY" multiplier="1.85" id="c6C-dq-01Y"/>
                             <constraint firstItem="Y5B-ds-Wwi" firstAttribute="top" secondItem="3HO-e8-lu3" secondAttribute="bottom" constant="20" id="g64-S3-Rjp"/>
-                            <constraint firstItem="g3a-fE-OqV" firstAttribute="leading" secondItem="Jhx-1G-qFV" secondAttribute="leading" constant="300" id="hkv-pd-Bjw"/>
                             <constraint firstItem="7nc-8V-HKl" firstAttribute="width" secondItem="HGk-3c-Ohq" secondAttribute="height" multiplier="137:448" constant="1" id="i7F-gu-hEf"/>
+                            <constraint firstItem="g3a-fE-OqV" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" multiplier="1.7" id="sQh-7X-R8i"/>
                             <constraint firstItem="7nc-8V-HKl" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" id="sZo-Op-2gz"/>
                             <constraint firstItem="Jhx-1G-qFV" firstAttribute="bottom" secondItem="3HO-e8-lu3" secondAttribute="bottom" constant="180" id="vrp-ki-x0g"/>
-                            <constraint firstItem="ycP-kV-iHe" firstAttribute="top" secondItem="Y5B-ds-Wwi" secondAttribute="bottom" constant="8" symbolic="YES" id="yGG-LT-DFl"/>
+                            <constraint firstItem="ycP-kV-iHe" firstAttribute="top" secondItem="Y5B-ds-Wwi" secondAttribute="bottom" constant="5" id="yGG-LT-DFl"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="qiw-P2-y7Q"/>

--- a/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
+++ b/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
@@ -50,25 +50,20 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="혹시 부모님이 갱년기 같으신가요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1eV-IS-3iG">
-                                <rect key="frame" x="47.5" y="652" width="319" height="29"/>
+                                <rect key="frame" x="47.5" y="653" width="319" height="29"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="갱년기는 급격한 호르몬 변화를 겪는 시기로" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDk-mg-it6">
-                                <rect key="frame" x="80.5" y="701" width="253.5" height="18"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" 대표적인 증상으로 무기력함과 우울감이 있어요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TyM-vL-RDw">
+                                <rect key="frame" x="65" y="763" width="284" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text=" 대표적인 증상으로 무기력함과 우울감이 있어요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TyM-vL-RDw">
-                                <rect key="frame" x="65" y="694.5" width="284" height="18"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IY4-tW-qWX">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IY4-tW-qWX">
                                 <rect key="frame" x="20" y="822.5" width="52" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Skip"/>
@@ -76,36 +71,37 @@
                                     <segue destination="NtZ-78-jYv" kind="show" id="7fl-9i-khf"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="szI-PR-2gr">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="szI-PR-2gr">
                                 <rect key="frame" x="340" y="822.5" width="54" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Next"/>
                                 <connections>
                                     <segue destination="lyG-OF-ikj" kind="show" id="ic6-UZ-Jqp"/>
                                 </connections>
                             </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="dadPicture" translatesAutoresizingMaskIntoConstraints="NO" id="Ab0-3b-621">
-                                <rect key="frame" x="46.5" y="191.5" width="321" height="341.5"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dadPicture" translatesAutoresizingMaskIntoConstraints="NO" id="Ab0-3b-621">
+                                <rect key="frame" x="40" y="70.5" width="334" height="584"/>
                             </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="갱년기는 급격한 호르몬 변화를 겪는 시기로" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDk-mg-it6">
+                                <rect key="frame" x="120" y="701" width="253.5" height="18"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="rmL-0a-M5c"/>
                         <color key="backgroundColor" name="dadDeepSkyblue"/>
                         <constraints>
-                            <constraint firstItem="szI-PR-2gr" firstAttribute="centerY" secondItem="rmL-0a-M5c" secondAttribute="centerY" multiplier="1.85" id="3pK-Ac-a51"/>
-                            <constraint firstItem="TyM-vL-RDw" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="5Wq-pv-FAG"/>
-                            <constraint firstItem="rmL-0a-M5c" firstAttribute="trailing" secondItem="szI-PR-2gr" secondAttribute="trailing" constant="20" id="Grd-fu-AWT"/>
-                            <constraint firstItem="1eV-IS-3iG" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="NAt-Jh-ohW"/>
-                            <constraint firstItem="MDk-mg-it6" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="O2N-3c-OQ1"/>
-                            <constraint firstItem="rmL-0a-M5c" firstAttribute="bottom" secondItem="1eV-IS-3iG" secondAttribute="bottom" constant="181" id="OqH-5V-yca"/>
-                            <constraint firstItem="Ab0-3b-621" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="RhT-LD-YjI"/>
-                            <constraint firstItem="Ab0-3b-621" firstAttribute="width" secondItem="OvF-j1-dXT" secondAttribute="height" multiplier="160:448" constant="1" id="WeC-uA-Prx"/>
-                            <constraint firstItem="IY4-tW-qWX" firstAttribute="leading" secondItem="rmL-0a-M5c" secondAttribute="leading" constant="20" id="XgD-7l-iFP"/>
-                            <constraint firstItem="szI-PR-2gr" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="IY4-tW-qWX" secondAttribute="trailing" constant="8" symbolic="YES" id="YX0-Q7-VG2"/>
-                            <constraint firstItem="MDk-mg-it6" firstAttribute="top" secondItem="1eV-IS-3iG" secondAttribute="bottom" constant="20" id="f6q-NH-TdA"/>
-                            <constraint firstItem="MDk-mg-it6" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="ilT-do-NKW"/>
-                            <constraint firstItem="Ab0-3b-621" firstAttribute="height" secondItem="OvF-j1-dXT" secondAttribute="height" multiplier="0.38" constant="1" id="mGE-MP-irR"/>
-                            <constraint firstItem="1eV-IS-3iG" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="tZq-yV-Cit"/>
-                            <constraint firstItem="IY4-tW-qWX" firstAttribute="centerY" secondItem="rmL-0a-M5c" secondAttribute="centerY" multiplier="1.85" id="xmF-KF-d3v"/>
+                            <constraint firstItem="Ab0-3b-621" firstAttribute="leading" secondItem="OvF-j1-dXT" secondAttribute="leading" constant="40" id="0jd-aX-L3e"/>
+                            <constraint firstItem="TyM-vL-RDw" firstAttribute="top" secondItem="MDk-mg-it6" secondAttribute="bottom" constant="43" id="98o-Hs-SI0"/>
+                            <constraint firstItem="TyM-vL-RDw" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="9I6-09-4yO"/>
+                            <constraint firstItem="MDk-mg-it6" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="PYA-vN-hk3"/>
+                            <constraint firstItem="1eV-IS-3iG" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="Sec-at-YbP"/>
+                            <constraint firstItem="rmL-0a-M5c" firstAttribute="bottom" secondItem="1eV-IS-3iG" secondAttribute="bottom" constant="180" id="a0U-8u-1iw"/>
+                            <constraint firstItem="MDk-mg-it6" firstAttribute="top" secondItem="1eV-IS-3iG" secondAttribute="bottom" constant="20" id="esP-Ty-7Eh"/>
+                            <constraint firstItem="Ab0-3b-621" firstAttribute="centerY" secondItem="rmL-0a-M5c" secondAttribute="centerY" multiplier="0.8" id="oVi-sp-lgE"/>
+                            <constraint firstItem="Ab0-3b-621" firstAttribute="centerX" secondItem="rmL-0a-M5c" secondAttribute="centerX" id="wW5-RL-HFW"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="BOv-Xa-CKc"/>
@@ -126,19 +122,19 @@
                                 <rect key="frame" x="69.5" y="131.5" width="275" height="462"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="부모님께 얼마나 자주 안부전화하나요?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3HO-e8-lu3">
-                                <rect key="frame" x="26.5" y="652" width="361" height="29"/>
+                                <rect key="frame" x="26.5" y="653" width="361" height="29"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="안부를 묻는 것만으로 갱년기 우울감 " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y5B-ds-Wwi">
-                                <rect key="frame" x="99.5" y="701" width="215" height="18"/>
+                                <rect key="frame" x="99.5" y="702" width="215" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완화에 도움이 된다고 해요!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ycP-kV-iHe">
-                                <rect key="frame" x="127" y="727" width="160" height="18"/>
+                                <rect key="frame" x="127" y="728" width="160" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.26051741839999998" green="0.2605243921" blue="0.260520637" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -178,7 +174,7 @@
                             <constraint firstItem="g3a-fE-OqV" firstAttribute="leading" secondItem="Jhx-1G-qFV" secondAttribute="leading" constant="300" id="hkv-pd-Bjw"/>
                             <constraint firstItem="7nc-8V-HKl" firstAttribute="width" secondItem="HGk-3c-Ohq" secondAttribute="height" multiplier="137:448" constant="1" id="i7F-gu-hEf"/>
                             <constraint firstItem="7nc-8V-HKl" firstAttribute="centerX" secondItem="Jhx-1G-qFV" secondAttribute="centerX" id="sZo-Op-2gz"/>
-                            <constraint firstItem="Jhx-1G-qFV" firstAttribute="bottom" secondItem="3HO-e8-lu3" secondAttribute="bottom" constant="181" id="vrp-ki-x0g"/>
+                            <constraint firstItem="Jhx-1G-qFV" firstAttribute="bottom" secondItem="3HO-e8-lu3" secondAttribute="bottom" constant="180" id="vrp-ki-x0g"/>
                             <constraint firstItem="ycP-kV-iHe" firstAttribute="top" secondItem="Y5B-ds-Wwi" secondAttribute="bottom" constant="8" symbolic="YES" id="yGG-LT-DFl"/>
                         </constraints>
                     </view>
@@ -276,7 +272,6 @@
                                     <action selector="nextButtonAction:" destination="NtZ-78-jYv" eventType="touchUpInside" id="qGZ-9G-edS"/>
                                     <action selector="setNotificationTime:" destination="4Mc-d9-Cdu" eventType="touchUpInside" id="o92-Kk-wcb"/>
                                     <action selector="startButttonAction:" destination="4Mc-d9-Cdu" eventType="touchUpInside" id="Nlf-hM-MQL"/>
-
                                     <segue destination="h9C-xi-h1l" kind="show" id="qjY-Is-6iQ"/>
                                 </connections>
                             </button>

--- a/TodayAnbu/Sources/Controllers/ConfirmViewController.swift
+++ b/TodayAnbu/Sources/Controllers/ConfirmViewController.swift
@@ -40,8 +40,6 @@ class ConfirmViewController: UIViewController {
         let testData = notification.object.self
         print("this is test Data \(testData ?? "테스트 데이터없음")")
     }
-
-
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -23,7 +23,6 @@ class MainViewController: UIViewController {
     var isMomCall = false
     var isDadCall = false
 
-    
     lazy var momCheckCount: Int = 0 {
         didSet {
             print("이게 될까?")

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -227,9 +227,7 @@ class MainViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(getNotificationFromConfirmView), name: NSNotification.Name("ConfirmView"), object: nil)
 
         CallManager.shared.$data
-            .sink { [weak self] in
-                print("main입니당", $0)
-            }
+            .sink { /*[weak self] in*/ print("main입니당", $0) }
             .store(in: &cancelBag)
 
         self.navigationItem.setHidesBackButton(true, animated: true)

--- a/TodayAnbu/Sources/Models/CallModelData.swift
+++ b/TodayAnbu/Sources/Models/CallModelData.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Combine
 
-
 struct CallData {
     var isMomCall: Bool = false
     var isDadCall: Bool = false
@@ -21,14 +20,14 @@ class CallManager: ObservableObject {
     static let shared = CallManager()
 }
 
-//class CallData: ObservableObject {
+// class CallData: ObservableObject {
 //    @Published var isMomCall: Bool = false
 //    @Published var isDadCall: Bool = false
 //    @Published var momCheckCount: Int = 0
 //    @Published var dadCheckCount: Int = 0
-//}
+// }
 //
-//class CallManager2 {
+// class CallManager2 {
 //    var data = CallData()
 //    static let shared = CallManager2()
-//}
+// }

--- a/TodayAnbu/Sources/SceneDelegate.swift
+++ b/TodayAnbu/Sources/SceneDelegate.swift
@@ -23,8 +23,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = UINavigationController(rootViewController: TabBarController())
         window?.makeKeyAndVisible()
          */
-
-
         // MARK: - 또 다른 스토리보드로 접근하고 싶을 경우
         /*
         let storyboard = UIStoryboard(name: "MemoStoryboard", bundle: nil)


### PR DESCRIPTION
## 개요
+ Onboarding Layout 수정 완료

<br/>

## 작업사항
### 작업 사항

+ 수정하기 전
<img width="950" alt="스크린샷 2022-07-30 오후 2 15 44" src="https://user-images.githubusercontent.com/81943525/182014262-237dc61c-8a00-42b1-a245-0df1ec4eb73b.png">
> 레이아웃이 깨지는 현상이 발생했습니다.


+ 온보딩 레이아웃이 맞지 않아서 제가 주로쓰는 방법인, vIew의 비율에 맞게 레이아웃을 조정하는 방식을 채택했습니다.

### References
- 없습니다.

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)

<img width="950" alt="스크린샷 2022-07-31 오후 4 04 17" src="https://user-images.githubusercontent.com/81943525/182014281-e6905a44-8b61-4c66-8749-ade5293ebafb.png">


<br/>

## 그외
### 리뷰 포인트

### 진행 예정 사항
[ ] button들의 layout을 통일
