### PR TITLE
feat: DatePicker Nil 에러 수정

### DIFF
--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A9128868F7100530B51 /* NotificationModalViewController.swift */; };
 		A9B32A94288691EA00530B51 /* NotificationTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B32A93288691EA00530B51 /* NotificationTime.swift */; };
 		A9CF7E652892D22700189E8B /* CallModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CF7E642892D22700189E8B /* CallModelData.swift */; };
-		B52841CB28922D7E004A2204 /* CallCheck.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B52841CA28922D7E004A2204 /* CallCheck.storyboard */; };
 		B52841D128926DA7004A2204 /* CallCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52841D028926DA7004A2204 /* CallCheckViewController.swift */; };
 		B55143EC2896785100D9E4D4 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55143EB2896785100D9E4D4 /* Storage.swift */; };
 /* End PBXBuildFile section */
@@ -472,7 +471,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -503,7 +502,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -316,7 +316,6 @@
 				3ED6D20A289280B8008F1D93 /* DadInitViewController.swift in Sources */,
 				A9B32A9228868F7100530B51 /* NotificationModalViewController.swift in Sources */,
 				3E2F6561287FA0E600A27FA9 /* SceneDelegate.swift in Sources */,
-				3EC0D9CB28801E9F00A98E73 /* MomInitViewController.swift in Sources */,
 				A9CF7E652892D22700189E8B /* CallModelData.swift in Sources */,
 				7B22167E2896129A00B14C5C /* MemoDetailViewController.swift in Sources */,
 				3EC0D9CB28801E9F00A98E73 /* MomInitViewController.swift in Sources */,

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -63,9 +63,9 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
     // MARK: 데이트 피커를 움직였을 때 나타나는 변화
     lazy private var timeLabel = timePicker.date {
         didSet {
-            print("현재 선택된 버튼의 개수는 다음과 같습니다 \(notificationButtonList.filter({$0.isSelected == true}).count)")
+            print("현재 선택된 버튼의 개수는 다음과 같습니다 \(notificationButtonList.filter({$0.isSelected == true}).count)") // test
             if notificationButtonList.filter({$0.isSelected == true}).isEmpty == false {
-                print("선택된 버튼이 있네요. 다음과 같습니다 button Index \(buttonIndex)")
+                print("선택된 버튼이 있네요. 다음과 같습니다 button Index \(buttonIndex)") // test
                 notificationButtonList[buttonIndex].notificationTime = timeLabel
                 if timeLabel.toString().isEmpty {
                     addNotificationTimeLabel(indexPath: buttonIndex, time: timeLabel.toString())
@@ -161,7 +161,7 @@ extension MomInitViewController {
         notificationButtonList[buttonIndex].buttonStack.arrangedSubviews[1].removeFromSuperview()
     }
 
-    //MARK: 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
+    // MARK: 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
     private func addNotificationTimeLabel(indexPath: Int, time: String) {
         let timeLabel: UILabel = {
             let label = UILabel()
@@ -170,13 +170,11 @@ extension MomInitViewController {
             label.textColor = .white
             return label
         }()
-
-        //MARK: 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
         if notificationButtonList[indexPath].buttonStack.subviews.count != 2 {
             notificationButtonList[indexPath].buttonStack.addArrangedSubview(timeLabel)
             notificationButtonList[indexPath].buttonStack.directionalLayoutMargins =  NSDirectionalEdgeInsets(top: 10, leading: 5, bottom: 10, trailing: 5)
 
-            //MARK: 알람 세팅된 버튼을 다시 클릭했을 경우
+            // MARK: 알람 세팅된 버튼을 다시 클릭했을 경우
         } else if notificationButtonList[indexPath].isSelected && notificationButtonList[indexPath].buttonStack.subviews.count == 2 {
             notificationButtonList[indexPath].buttonStack.subviews[1].removeFromSuperview()
             notificationButtonList[indexPath].buttonStack.directionalLayoutMargins =  NSDirectionalEdgeInsets(top: 15, leading: 15, bottom: 15, trailing: 15)

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -60,16 +60,19 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
         }
     }
 
-    // 데이트 피커를 움직였을 때 나타나는 변화
+    // MARK: 데이트 피커를 움직였을 때 나타나는 변화
     lazy private var timeLabel = timePicker.date {
         didSet {
-            notificationButtonList[buttonIndex].notificationTime = timeLabel
-
-            if timeLabel.toString().isEmpty {
-                addNotificationTimeLabel(indexPath: buttonIndex, time: timeLabel.toString())
-            } else {
-                removeTimeLabel()
-                addNotificationTimeLabel(indexPath: buttonIndex, time: timeLabel.toString())
+            print("현재 선택된 버튼의 개수는 다음과 같습니다 \(notificationButtonList.filter({$0.isSelected == true}).count)")
+            if notificationButtonList.filter({$0.isSelected == true}).isEmpty == false {
+                print("선택된 버튼이 있네요. 다음과 같습니다 button Index \(buttonIndex)")
+                notificationButtonList[buttonIndex].notificationTime = timeLabel
+                if timeLabel.toString().isEmpty {
+                    addNotificationTimeLabel(indexPath: buttonIndex, time: timeLabel.toString())
+                } else if notificationButtonList[buttonIndex].buttonStack.subviews.count == 2 {
+                    removeTimeLabel()
+                    addNotificationTimeLabel(indexPath: buttonIndex, time: timeLabel.toString())
+                }
             }
         }
     }
@@ -104,7 +107,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
                 print(error ?? "No error")
             }
         }
-//        self.navigationItem.setHidesBackButton(true, animated: true)
+        //        self.navigationItem.setHidesBackButton(true, animated: true)
     }
 
     @IBAction func startButttonAction(_ sender: Any) {
@@ -158,7 +161,7 @@ extension MomInitViewController {
         notificationButtonList[buttonIndex].buttonStack.arrangedSubviews[1].removeFromSuperview()
     }
 
-    // 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
+    //MARK: 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
     private func addNotificationTimeLabel(indexPath: Int, time: String) {
         let timeLabel: UILabel = {
             let label = UILabel()
@@ -168,11 +171,12 @@ extension MomInitViewController {
             return label
         }()
 
+        //MARK: 데이트 피커가 설정한 시간에 따라 타임 레이블을 추가하는 함수
         if notificationButtonList[indexPath].buttonStack.subviews.count != 2 {
             notificationButtonList[indexPath].buttonStack.addArrangedSubview(timeLabel)
             notificationButtonList[indexPath].buttonStack.directionalLayoutMargins =  NSDirectionalEdgeInsets(top: 10, leading: 5, bottom: 10, trailing: 5)
 
-            // 알람 세팅된 버튼을 다시 클릭했을 경우
+            //MARK: 알람 세팅된 버튼을 다시 클릭했을 경우
         } else if notificationButtonList[indexPath].isSelected && notificationButtonList[indexPath].buttonStack.subviews.count == 2 {
             notificationButtonList[indexPath].buttonStack.subviews[1].removeFromSuperview()
             notificationButtonList[indexPath].buttonStack.directionalLayoutMargins =  NSDirectionalEdgeInsets(top: 15, leading: 15, bottom: 15, trailing: 15)


### PR DESCRIPTION
## 개요
알람 설정 요일이 아무것도 없을 때 date picker 휠을 돌리면 앱이 깨지는 현상 발생

## 이유
알람 설정된 요일 버튼을 다시 누르면 time label이 없어지는데, date picker 값 변경에 따라 time label이 없어지는 코드가 존재했다
그래서 조건을 걸어서 요일 버튼이 선택된 게 없을 경우에만 그 코드가 실행되도록 바꾸었습니다. 

## 테스트 결과 
시간이 없는 관계로 생략 
