### PR TITLE
#126 feat: navigationError 수정

### DIFF
--- a/TodayAnbu/Sources/Controllers/TabBarController.swift
+++ b/TodayAnbu/Sources/Controllers/TabBarController.swift
@@ -12,8 +12,8 @@ class TabBarController: UITabBarController {
         view.backgroundColor = .white
 
         let firstTab = UINavigationController(rootViewController: MainViewController())
+
         let secondTab = UIStoryboard(name: "MemoStoryboard", bundle: nil).instantiateViewController(withIdentifier: "MemoViewController")
-        self.navigationController?.pushViewController(secondTab, animated: true)
 
         firstTab.tabBarItem.image = UIImage(systemName: "house")
         firstTab.tabBarItem.selectedImage = UIImage(systemName: "house.fill")


### PR DESCRIPTION
## 개요
온보딩 페이지 되자마자 메모뷰로 전환되는 문제 해결

## 문제 이유
메인뷰 ViewDidLoad에 navigate 시키는 코드가 있었습니다.
그래서 메인뷰가 되자마자 다음 뷰로 넘어가게 됨.
