### PR TITLE
[fix] settingButton 오류 해결함

### DIFF
--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -125,8 +125,7 @@ class MainViewController: UIViewController {
     private lazy var settingButton: UIButton = {
         let setButton = UIButton()
         setButton.setImage(UIImage(systemName: "gearshape.fill"), for: UIControl.State.normal)
-
-        setButton.backgroundColor = .red
+        setButton.backgroundColor = .mainIndigo
         setButton.tintColor = .white
         setButton.addTarget(self, action: #selector(setButtonAction(_:)), for: .touchUpInside)
         return setButton
@@ -344,14 +343,14 @@ class MainViewController: UIViewController {
         ])
         NSLayoutConstraint.activate([
             topTitle.leadingAnchor.constraint(equalTo: topArea.leadingAnchor, constant: 20),
-            topTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: -40)
+            topTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10)
         ])
         NSLayoutConstraint.activate([
             topTitleDays.leadingAnchor.constraint(equalTo: topArea.leadingAnchor, constant: 112),
             topTitleDays.bottomAnchor.constraint(equalTo: topTitle.bottomAnchor)
         ])
         NSLayoutConstraint.activate([
-            settingButton.topAnchor.constraint(equalTo: weeklyAnbuLabel.topAnchor),
+            settingButton.centerYAnchor.constraint(equalTo: topTitle.centerYAnchor),
             settingButton.widthAnchor.constraint(equalToConstant: 40),
             settingButton.trailingAnchor.constraint(equalTo: topArea.trailingAnchor, constant: -20)
         ])

--- a/TodayAnbu/Sources/Controllers/TabBarController.swift
+++ b/TodayAnbu/Sources/Controllers/TabBarController.swift
@@ -17,7 +17,7 @@ class TabBarController: UITabBarController {
 
         firstTab.tabBarItem.image = UIImage(systemName: "house")
         firstTab.tabBarItem.selectedImage = UIImage(systemName: "house.fill")
-
+        firstTab.isNavigationBarHidden = true
         secondTab.tabBarItem.image = UIImage(systemName: "book")
         secondTab.tabBarItem.selectedImage = UIImage(systemName: "book.fill")
 


### PR DESCRIPTION
## 개요
세팅버튼이 뷰 계층에서 네비게이션 바 아래에 있던 문제 해결함

<br/>

## 작업사항
### 작업 사항
네비게이션 바 삭제 후 topicTitle의 탑앵커가 잘못 잡혀있었던 문제 해결
세팅버튼이 뷰 계층에서 네비게이션 바 아래에 있던 문제 해결함

### References
ex) 작업시 참고한 자료가 있다면 추가해주세요!
  - [세팅버튼 수정](Hardy의 머리속)

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)

<p align="left">
  <img width="250" alt="화면1" src="https://user-images.githubusercontent.com/81131715/182139307-24e41471-c713-4164-a8ca-80dff7434398.gif">
</p>


<br/>

## 그외
### 리뷰 포인트
ex) 리뷰받고 싶은 내용, 고민한 내용  등에 대해 적어주세요
- Anything

### 진행 예정 사항
ex) 작업 진행 예정사항 및 개선하고 싶은 내용이 있다면 추가 해주세요
- [ ] 메인 뷰 카운트 작업 도전?
