### PR TITLE
#134 [feat]: UserDefaults 알람 데이터 저장 + 알람 재활성화 기능 추가

### DIFF
--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -532,7 +532,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N6FVFS939;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -564,7 +564,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5N6FVFS939;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -111,7 +111,8 @@ class DadInitViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func startButttonAction(_ sender: Any) {
         if dadNumberTextfield.hasValidPhoneNumber {
-            UserDefaults.standard.set(dadNumberTextfield.text!, forKey: "dadPhoneNumber")
+            dadPhoneNumber = dadNumberTextfield.text!
+            UserDefaults.standard.set(dadPhoneNumber, forKey: "dadPhoneNumber")
         }
     }
     @IBAction func timePickerAction(_ sender: UIDatePicker!) {
@@ -257,7 +258,6 @@ extension DadInitViewController {
 }
 
 extension DadInitViewController {
-    // MARK: 알람 설정 완료 함수
     @IBAction func setNotificationTime(_ sender: Any) {
         var dateList: [Date] = []
         var dayList: [Int] = []
@@ -265,9 +265,6 @@ extension DadInitViewController {
             dateList.append(button.notificationTime)
             dayList.append(button.indexPath)
         }
-
-        UserDefaults.standard.set(dateList, forKey: "Dad-FirstSetting-dateList")
-        UserDefaults.standard.set(dayList, forKey: "Dad-FirstSetting-dayList")
 
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -111,7 +111,8 @@ class DadInitViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func startButttonAction(_ sender: Any) {
         if dadNumberTextfield.hasValidPhoneNumber {
-            UserDefaults.standard.set(dadNumberTextfield.text!, forKey: "dadPhoneNumber")
+            dadPhoneNumber = dadNumberTextfield.text!
+             UserDefaults.standard.set(dadPhoneNumber, forKey: "dadPhoneNumber")
         }
     }
     @IBAction func timePickerAction(_ sender: UIDatePicker!) {

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -111,8 +111,7 @@ class DadInitViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func startButttonAction(_ sender: Any) {
         if dadNumberTextfield.hasValidPhoneNumber {
-            dadPhoneNumber = dadNumberTextfield.text!
-            UserDefaults.standard.set(dadPhoneNumber, forKey: "dadPhoneNumber")
+            UserDefaults.standard.set(dadNumberTextfield.text!, forKey: "dadPhoneNumber")
         }
     }
     @IBAction func timePickerAction(_ sender: UIDatePicker!) {
@@ -258,6 +257,7 @@ extension DadInitViewController {
 }
 
 extension DadInitViewController {
+    // MARK: 알람 설정 완료 함수
     @IBAction func setNotificationTime(_ sender: Any) {
         var dateList: [Date] = []
         var dayList: [Int] = []
@@ -265,6 +265,9 @@ extension DadInitViewController {
             dateList.append(button.notificationTime)
             dayList.append(button.indexPath)
         }
+
+        UserDefaults.standard.set(dateList, forKey: "Dad-FirstSetting-dateList")
+        UserDefaults.standard.set(dayList, forKey: "Dad-FirstSetting-dayList")
 
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -115,8 +115,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func startButttonAction(_ sender: Any) {
         if momNumberTextfield.hasValidPhoneNumber {
-            momPhoneNumber = momNumberTextfield.text!
-            UserDefaults.standard.set(momPhoneNumber, forKey: "momPhoneNumber")
+            UserDefaults.standard.set(momNumberTextfield.text!, forKey: "momPhoneNumber")
         }
     }
     @IBAction func timePickerAction(_ sender: UIDatePicker!) {
@@ -260,6 +259,7 @@ extension MomInitViewController {
 }
 
 extension MomInitViewController {
+    // MARK: 알람 설정 완료 함수
     @IBAction func setNotificationTime(_ sender: Any) {
         var dateList: [Date] = []
         var dayList: [Int] = []
@@ -267,6 +267,9 @@ extension MomInitViewController {
             dateList.append(button.notificationTime)
             dayList.append(button.indexPath)
         }
+
+        UserDefaults.standard.set(dateList, forKey: "Mom-FirstSetting-dateList")
+        UserDefaults.standard.set(dayList, forKey: "Mom-FirstSetting-dayList")
 
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {
@@ -281,6 +284,7 @@ extension MomInitViewController {
                     if dayList.isEmpty == false {
                         for index in 0...dayList.count-1 {
                             var dateComponent = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: dateList[index])
+
                             let weekDay: Int = {
                                 var weekDay = dayList[index] + 2
                                 if weekDay == 8 {
@@ -288,7 +292,9 @@ extension MomInitViewController {
                                 }
                                 return weekDay
                             }()
+
                             dateComponent.weekday = weekDay
+
                             let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
                             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
                             self.notificationCenter.add(request) { error in

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -115,7 +115,8 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func startButttonAction(_ sender: Any) {
         if momNumberTextfield.hasValidPhoneNumber {
-            UserDefaults.standard.set(momNumberTextfield.text!, forKey: "momPhoneNumber")
+            momPhoneNumber = momNumberTextfield.text!
+            UserDefaults.standard.set(momPhoneNumber, forKey: "momPhoneNumber")
         }
     }
     @IBAction func timePickerAction(_ sender: UIDatePicker!) {
@@ -259,7 +260,6 @@ extension MomInitViewController {
 }
 
 extension MomInitViewController {
-    // MARK: 알람 설정 완료 함수
     @IBAction func setNotificationTime(_ sender: Any) {
         var dateList: [Date] = []
         var dayList: [Int] = []
@@ -267,9 +267,6 @@ extension MomInitViewController {
             dateList.append(button.notificationTime)
             dayList.append(button.indexPath)
         }
-
-        UserDefaults.standard.set(dateList, forKey: "Mom-FirstSetting-dateList")
-        UserDefaults.standard.set(dayList, forKey: "Mom-FirstSetting-dayList")
 
         notificationCenter.getNotificationSettings { settings in
             DispatchQueue.main.async {
@@ -284,7 +281,6 @@ extension MomInitViewController {
                     if dayList.isEmpty == false {
                         for index in 0...dayList.count-1 {
                             var dateComponent = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: dateList[index])
-
                             let weekDay: Int = {
                                 var weekDay = dayList[index] + 2
                                 if weekDay == 8 {
@@ -292,9 +288,7 @@ extension MomInitViewController {
                                 }
                                 return weekDay
                             }()
-
                             dateComponent.weekday = weekDay
-
                             let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
                             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
                             self.notificationCenter.add(request) { error in

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -115,7 +115,8 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func startButttonAction(_ sender: Any) {
         if momNumberTextfield.hasValidPhoneNumber {
-            UserDefaults.standard.set(momNumberTextfield.text!, forKey: "momPhoneNumber")
+            momPhoneNumber = momNumberTextfield.text!
+             UserDefaults.standard.set(momPhoneNumber, forKey: "momPhoneNumber")
         }
     }
     @IBAction func timePickerAction(_ sender: UIDatePicker!) {

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -58,99 +58,14 @@ class SettingViewController: UIViewController {
             tableView.rightAnchor.constraint(equalTo: view.rightAnchor)
         ])
     }
-
     @objc func changedSwitch(_ sender: UISwitch) {
         print(sender.isOn)
         if !sender.isOn {
             removeLocalNotifications()
-            let notificationAlert = UIAlertController(title: "알람 비활성화", message: "원래 설정한 알람을 중단할게요! ", preferredStyle: .alert)
-            notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
-            }))
-            self.present(notificationAlert, animated: true)
-
-        } else {
-            let notificationCenter = UNUserNotificationCenter.current()
-            let userDefaultsData = UserDefaults.standard
-
-            let momDateList = userDefaultsData.object(forKey: "Mom-FirstSetting-dateList") as? [Date] ?? [Date()]
-            let momDayList = userDefaultsData.object(forKey: "Mom-FirstSetting-dayList") as? [Int] ?? [0]
-
-            let dadDateList = userDefaultsData.object(forKey: "Dad-FirstSetting-dateList") as? [Date] ?? [Date()]
-            let dadDayList = userDefaultsData.object(forKey: "Dad-FirstSetting-dayList") as? [Int] ?? [0]
-
-            let dateList: [Date] = momDateList + dadDateList
-            let dayList: [Int] = momDayList + dadDayList
-
-            notificationCenter.getNotificationSettings { settings in
-                DispatchQueue.main.async {
-                    let title = "어머니에게 안부 전화드려보세요!"
-                    let message = "오늘의 토픽 주제로 이야기해봐요!"
-
-                    if settings.authorizationStatus == .authorized {
-                        let content = UNMutableNotificationContent()
-                        content.title = title
-                        content.body = message
-
-                        if dayList.isEmpty == false {
-                            var requestNumber = 0
-                            for index in 0...dayList.count-1 {
-                                var dateComponent = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: dateList[index])
-
-                                let weekDay: Int = {
-                                    var weekDay = dayList[index] + 2
-                                    if weekDay == 8 {
-                                        weekDay = 1
-                                    }
-                                    return weekDay
-                                }()
-
-                                dateComponent.weekday = weekDay
-
-                                let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
-                                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
-                                notificationCenter.add(request) { error in
-                                    if error != nil {
-                                        print("Error " + error.debugDescription)
-                                        return
-                                    }
-                                }
-                                requestNumber += 1
-
-                                print("RE: request에 요청된 날짜 정보는 다음과 같습니다. \(dateComponent)") // Test
-                                print("RE: notification center에 요청된 정보는 다음과 같습니다 \(request)") // Test
-
-                                print("총 전송된 request의 개수는 다음과 같습니다. \(requestNumber)")
-                            }
-                        } else {
-                            let notificationAlert = UIAlertController(title: "알람을 설정하지 않으셨나요?", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
-                            notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
-                            }))
-                            self.present(notificationAlert, animated: true)
-                        }
-
-                        let notificationAlert = UIAlertController(title: "알람 재활성화", message: "원래 설정했던 대로 다시 알람을 드릴게요! ", preferredStyle: .alert)
-                        notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
-                        }))
-                        self.present(notificationAlert, animated: true)
-
-                    } else {
-                        let alertController = UIAlertController(title: "알림을 설정하시겠어요?", message: "설정에서 알람 허용을 해주셔야해요!", preferredStyle: .alert)
-                        let goToSettings = UIAlertAction(title: "설정", style: .default) { _ in
-                            guard let settingURL = URL(string: UIApplication.openSettingsURLString) else {
-                                return
-                            }
-                            if UIApplication.shared.canOpenURL(settingURL) {
-                                UIApplication.shared.open(settingURL) { (_) in}
-                            }
-                        }
-                        alertController.addAction(goToSettings)
-                        alertController.addAction(UIAlertAction(title: "취소", style: .default, handler: { (_) in
-                        }))
-                        self.present(alertController, animated: true)
-                    }
-                }
-            }
         }
+//        let state = switchOnAndOff.isOn ? "On" : "Off"
+//        print(state)
+
     }
 
     func removeLocalNotifications() {
@@ -216,6 +131,13 @@ extension SettingViewController: UITableViewDataSource {
 }
 
 extension SettingViewController: UITableViewDelegate {
+//    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+//        let header = SettingHeaderView()
+//        return header
+//    }
+//    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+//        return 300
+//    }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         print("지금 \(indexPath.row) 선택")

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -58,14 +58,99 @@ class SettingViewController: UIViewController {
             tableView.rightAnchor.constraint(equalTo: view.rightAnchor)
         ])
     }
+
     @objc func changedSwitch(_ sender: UISwitch) {
         print(sender.isOn)
         if !sender.isOn {
             removeLocalNotifications()
-        }
-//        let state = switchOnAndOff.isOn ? "On" : "Off"
-//        print(state)
+            let notificationAlert = UIAlertController(title: "알람 비활성화", message: "원래 설정한 알람을 중단할게요! ", preferredStyle: .alert)
+            notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+            }))
+            self.present(notificationAlert, animated: true)
 
+        } else {
+            let notificationCenter = UNUserNotificationCenter.current()
+            let userDefaultsData = UserDefaults.standard
+
+            let momDateList = userDefaultsData.object(forKey: "Mom-FirstSetting-dateList") as? [Date] ?? [Date()]
+            let momDayList = userDefaultsData.object(forKey: "Mom-FirstSetting-dayList") as? [Int] ?? [0]
+
+            let dadDateList = userDefaultsData.object(forKey: "Dad-FirstSetting-dateList") as? [Date] ?? [Date()]
+            let dadDayList = userDefaultsData.object(forKey: "Dad-FirstSetting-dayList") as? [Int] ?? [0]
+
+            let dateList: [Date] = momDateList + dadDateList
+            let dayList: [Int] = momDayList + dadDayList
+
+            notificationCenter.getNotificationSettings { settings in
+                DispatchQueue.main.async {
+                    let title = "어머니에게 안부 전화드려보세요!"
+                    let message = "오늘의 토픽 주제로 이야기해봐요!"
+
+                    if settings.authorizationStatus == .authorized {
+                        let content = UNMutableNotificationContent()
+                        content.title = title
+                        content.body = message
+
+                        if dayList.isEmpty == false {
+                            var requestNumber = 0
+                            for index in 0...dayList.count-1 {
+                                var dateComponent = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: dateList[index])
+
+                                let weekDay: Int = {
+                                    var weekDay = dayList[index] + 2
+                                    if weekDay == 8 {
+                                        weekDay = 1
+                                    }
+                                    return weekDay
+                                }()
+
+                                dateComponent.weekday = weekDay
+
+                                let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: true)
+                                let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+                                notificationCenter.add(request) { error in
+                                    if error != nil {
+                                        print("Error " + error.debugDescription)
+                                        return
+                                    }
+                                }
+                                requestNumber += 1
+
+                                print("RE: request에 요청된 날짜 정보는 다음과 같습니다. \(dateComponent)") // Test
+                                print("RE: notification center에 요청된 정보는 다음과 같습니다 \(request)") // Test
+
+                                print("총 전송된 request의 개수는 다음과 같습니다. \(requestNumber)")
+                            }
+                        } else {
+                            let notificationAlert = UIAlertController(title: "알람을 설정하지 않으셨나요?", message: "알람은 설정창에서 바꿀 수 있어요! ", preferredStyle: .alert)
+                            notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                            }))
+                            self.present(notificationAlert, animated: true)
+                        }
+
+                        let notificationAlert = UIAlertController(title: "알람 재활성화", message: "원래 설정했던 대로 다시 알람을 드릴게요! ", preferredStyle: .alert)
+                        notificationAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                        }))
+                        self.present(notificationAlert, animated: true)
+
+                    } else {
+                        let alertController = UIAlertController(title: "알림을 설정하시겠어요?", message: "설정에서 알람 허용을 해주셔야해요!", preferredStyle: .alert)
+                        let goToSettings = UIAlertAction(title: "설정", style: .default) { _ in
+                            guard let settingURL = URL(string: UIApplication.openSettingsURLString) else {
+                                return
+                            }
+                            if UIApplication.shared.canOpenURL(settingURL) {
+                                UIApplication.shared.open(settingURL) { (_) in}
+                            }
+                        }
+                        alertController.addAction(goToSettings)
+                        alertController.addAction(UIAlertAction(title: "취소", style: .default, handler: { (_) in
+                        }))
+                        self.present(alertController, animated: true)
+                    }
+                }
+            }
+        }
     }
 
     func removeLocalNotifications() {
@@ -131,13 +216,6 @@ extension SettingViewController: UITableViewDataSource {
 }
 
 extension SettingViewController: UITableViewDelegate {
-//    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-//        let header = SettingHeaderView()
-//        return header
-//    }
-//    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-//        return 300
-//    }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         print("지금 \(indexPath.row) 선택")

--- a/TodayAnbu/Sources/SceneDelegate.swift
+++ b/TodayAnbu/Sources/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
-//        setRootViewController(scene)
+        setRootViewController(scene)
         // MARK: 개발 생산성을 위해 엔트리 포인트를 고정하고자 하는 경우 아래의 코드에서 rootViewController를 지정하여 사용
         /*
         guard let scene = (scene as? UIWindowScene) else { return }

--- a/TodayAnbu/Sources/SceneDelegate.swift
+++ b/TodayAnbu/Sources/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
-        setRootViewController(scene)
+//        setRootViewController(scene)
         // MARK: 개발 생산성을 위해 엔트리 포인트를 고정하고자 하는 경우 아래의 코드에서 rootViewController를 지정하여 사용
         /*
         guard let scene = (scene as? UIWindowScene) else { return }


### PR DESCRIPTION
## 작업사항
1. UserDefaults에 초기에 설정한 아버지, 어머니의 알람 시간 정보를 저장합니다.
2. 저장된 정보를 사용해서 사용자가 세팅뷰에서 알람을 다시 활성화했을때, 자동으로 NotificationCenter에 기존의 정보를 request합니다. 3. 

## 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103009135/182147238-fa9996d4-869a-4b1e-9a58-533c35baac40.png">

### 어머니 3개 알람 설정 request 3개

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103009135/182147340-2bf18060-eed2-4b8f-b9d3-12429856a010.png">

### 아버지는 2개 설정

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103009135/182148019-4ee9ca28-d547-4de1-8f3a-da6ce5e3d963.png">

### 알람 비활성화시 alert추가

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/103009135/182148088-1cb53e18-e67f-4cb8-a8f3-9995c90a87c5.png">

### 재설정했을 경우 request 5개가 다시 전송되는것 확인 

## References
None
