### PR TITLE
[Refactor]: [#128] Main Button layout 통일

### DIFF
--- a/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
+++ b/TodayAnbu/Sources/Boards/Base.lproj/Main.storyboard
@@ -251,7 +251,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDx-zU-TUQ">
-                                <rect key="frame" x="20" y="799.5" width="374" height="62.5"/>
+                                <rect key="frame" x="10" y="796.5" width="394" height="65.5"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="GDx-zU-TUQ" secondAttribute="height" multiplier="6:1" id="3i8-Z5-aIH"/>
@@ -297,7 +297,7 @@
                             <constraint firstItem="GDx-zU-TUQ" firstAttribute="bottom" secondItem="2wo-x5-dQC" secondAttribute="bottom" id="jcg-eg-q0J"/>
                             <constraint firstItem="8t4-E2-kdY" firstAttribute="top" secondItem="ADn-HQ-d5a" secondAttribute="bottom" constant="8" symbolic="YES" id="mdn-c7-tj6"/>
                             <constraint firstItem="2F2-DC-QjR" firstAttribute="leading" secondItem="8t4-E2-kdY" secondAttribute="leading" constant="-3" id="tr7-EL-o3Y"/>
-                            <constraint firstItem="GDx-zU-TUQ" firstAttribute="leading" secondItem="2wo-x5-dQC" secondAttribute="leading" constant="20" id="uTI-LS-GYx"/>
+                            <constraint firstItem="GDx-zU-TUQ" firstAttribute="leading" secondItem="2wo-x5-dQC" secondAttribute="leading" constant="10" id="uTI-LS-GYx"/>
                             <constraint firstItem="sWU-HB-90u" firstAttribute="centerX" secondItem="2wo-x5-dQC" secondAttribute="centerX" id="x0g-Tm-atc"/>
                             <constraint firstItem="ADn-HQ-d5a" firstAttribute="leading" secondItem="2wo-x5-dQC" secondAttribute="leading" constant="20" id="x4J-na-skg"/>
                         </constraints>
@@ -322,10 +322,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g7z-be-atv">
-                                <rect key="frame" x="30" y="742" width="354" height="55"/>
+                                <rect key="frame" x="10" y="776.5" width="394" height="65.5"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="VXw-CS-WK9"/>
+                                    <constraint firstAttribute="width" secondItem="g7z-be-atv" secondAttribute="height" multiplier="6:1" id="fH5-HV-Ieb"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                 <color key="tintColor" systemColor="systemGray2Color"/>
@@ -377,7 +377,7 @@
                                 </constraints>
                             </stackView>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="wheels" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DWi-DD-i5O">
-                                <rect key="frame" x="47" y="446" width="320" height="216"/>
+                                <rect key="frame" x="47" y="480.5" width="320" height="216"/>
                                 <date key="date" timeIntervalSinceReferenceDate="680443200.35427201">
                                     <!--2022-07-25 12:00:00 +0000-->
                                 </date>
@@ -390,15 +390,16 @@
                         <viewLayoutGuide key="safeArea" id="Hxi-ne-mDj"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="g7z-be-atv" firstAttribute="top" secondItem="DWi-DD-i5O" secondAttribute="bottom" constant="80" id="3td-dD-pCZ"/>
                             <constraint firstItem="Vah-c9-XoB" firstAttribute="leading" secondItem="Hxi-ne-mDj" secondAttribute="leading" constant="20" id="4OO-m7-h7P"/>
                             <constraint firstItem="DWi-DD-i5O" firstAttribute="centerX" secondItem="h2M-uD-n9d" secondAttribute="centerX" id="4ei-Ia-fQE"/>
                             <constraint firstItem="Vah-c9-XoB" firstAttribute="top" secondItem="Hxi-ne-mDj" secondAttribute="top" constant="35" id="HJ3-5c-DdX"/>
-                            <constraint firstItem="Hxi-ne-mDj" firstAttribute="bottom" secondItem="g7z-be-atv" secondAttribute="bottom" constant="45" id="Kwf-zU-3IG"/>
-                            <constraint firstItem="Hxi-ne-mDj" firstAttribute="trailing" secondItem="g7z-be-atv" secondAttribute="trailing" constant="30" id="XeA-mY-Eot"/>
-                            <constraint firstItem="g7z-be-atv" firstAttribute="leading" secondItem="Hxi-ne-mDj" secondAttribute="leading" constant="30" id="hqc-iH-g9A"/>
+                            <constraint firstItem="Hxi-ne-mDj" firstAttribute="trailing" secondItem="g7z-be-atv" secondAttribute="trailing" constant="10" id="PbU-tc-zys"/>
+                            <constraint firstItem="g7z-be-atv" firstAttribute="leading" secondItem="Hxi-ne-mDj" secondAttribute="leading" constant="10" id="U94-3m-eFv"/>
+                            <constraint firstItem="Hxi-ne-mDj" firstAttribute="bottom" secondItem="g7z-be-atv" secondAttribute="bottom" id="ePX-Nr-EeC"/>
                             <constraint firstItem="DWi-DD-i5O" firstAttribute="centerX" secondItem="h2M-uD-n9d" secondAttribute="centerX" id="mUn-28-pap"/>
+                            <constraint firstItem="g7z-be-atv" firstAttribute="centerX" secondItem="Hxi-ne-mDj" secondAttribute="centerX" id="q8W-XB-5Js"/>
                             <constraint firstItem="Hxi-ne-mDj" firstAttribute="trailing" secondItem="Vah-c9-XoB" secondAttribute="trailing" constant="20" id="vDC-eL-kIB"/>
-                            <constraint firstItem="g7z-be-atv" firstAttribute="top" secondItem="DWi-DD-i5O" secondAttribute="bottom" constant="80" id="yTG-TV-qsL"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="tIN-Ib-94p"/>
@@ -423,10 +424,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ur-6N-Yl4">
-                                <rect key="frame" x="30" y="742" width="354" height="55"/>
+                                <rect key="frame" x="10" y="776.5" width="394" height="65.5"/>
                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="PsX-6U-1To"/>
+                                    <constraint firstAttribute="width" secondItem="1Ur-6N-Yl4" secondAttribute="height" multiplier="6:1" id="EcO-uG-jNt"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                 <color key="tintColor" systemColor="systemGray2Color"/>
@@ -478,7 +479,7 @@
                                 </constraints>
                             </stackView>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="wheels" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="INX-g1-5ve">
-                                <rect key="frame" x="47" y="446" width="320" height="216"/>
+                                <rect key="frame" x="47" y="480.5" width="320" height="216"/>
                                 <date key="date" timeIntervalSinceReferenceDate="680443200.35427201">
                                     <!--2022-07-25 12:00:00 +0000-->
                                 </date>
@@ -495,9 +496,9 @@
                             <constraint firstItem="INX-g1-5ve" firstAttribute="centerX" secondItem="EgN-68-aUZ" secondAttribute="centerX" id="1kF-iB-hys"/>
                             <constraint firstItem="gRx-5R-oRU" firstAttribute="top" secondItem="XpS-Uu-a7J" secondAttribute="top" constant="35" id="Dd5-wR-qeJ"/>
                             <constraint firstItem="XpS-Uu-a7J" firstAttribute="trailing" secondItem="gRx-5R-oRU" secondAttribute="trailing" constant="20" id="Ivb-9I-rkz"/>
-                            <constraint firstItem="1Ur-6N-Yl4" firstAttribute="leading" secondItem="XpS-Uu-a7J" secondAttribute="leading" constant="30" id="M3d-86-beA"/>
-                            <constraint firstItem="XpS-Uu-a7J" firstAttribute="bottom" secondItem="1Ur-6N-Yl4" secondAttribute="bottom" constant="45" id="Teg-4p-zWt"/>
-                            <constraint firstItem="XpS-Uu-a7J" firstAttribute="trailing" secondItem="1Ur-6N-Yl4" secondAttribute="trailing" constant="30" id="UjK-Ny-IkN"/>
+                            <constraint firstItem="1Ur-6N-Yl4" firstAttribute="centerX" secondItem="XpS-Uu-a7J" secondAttribute="centerX" id="Nqe-Ca-Nme"/>
+                            <constraint firstItem="XpS-Uu-a7J" firstAttribute="bottom" secondItem="1Ur-6N-Yl4" secondAttribute="bottom" id="Teg-4p-zWt"/>
+                            <constraint firstItem="XpS-Uu-a7J" firstAttribute="trailing" secondItem="1Ur-6N-Yl4" secondAttribute="trailing" constant="10" id="UjK-Ny-IkN"/>
                             <constraint firstItem="1Ur-6N-Yl4" firstAttribute="top" secondItem="INX-g1-5ve" secondAttribute="bottom" constant="80" id="ktD-8B-aTi"/>
                             <constraint firstItem="INX-g1-5ve" firstAttribute="centerX" secondItem="EgN-68-aUZ" secondAttribute="centerX" id="xf1-Ay-ci2"/>
                         </constraints>
@@ -551,7 +552,10 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nrb-rx-Yye">
-                                <rect key="frame" x="15" y="724" width="384" height="59"/>
+                                <rect key="frame" x="10" y="720.5" width="394" height="66"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="Nrb-rx-Yye" secondAttribute="height" multiplier="6:1" id="6ba-Ci-PrB"/>
+                                </constraints>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="안부 완료" cornerStyle="medium" buttonSize="large">
                                     <fontDescription key="titleFontDescription" type="system" weight="black" pointSize="24"/>
@@ -560,7 +564,10 @@
                                 </buttonConfiguration>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f9F-UN-SBB">
-                                <rect key="frame" x="15" y="793" width="384" height="59"/>
+                                <rect key="frame" x="10" y="796.5" width="394" height="65.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="f9F-UN-SBB" secondAttribute="height" multiplier="6:1" id="4Gk-Q5-2CZ"/>
+                                </constraints>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="안부 완료"/>
                                 <buttonConfiguration key="configuration" style="gray" title="아니오. 안 받으셨어요." cornerStyle="medium" buttonSize="large">
@@ -582,12 +589,12 @@
                         <constraints>
                             <constraint firstItem="cmq-pv-rzu" firstAttribute="centerY" secondItem="Nte-GU-lcs" secondAttribute="centerY" multiplier="0.566" id="1oh-Rb-WLZ"/>
                             <constraint firstItem="f9F-UN-SBB" firstAttribute="centerX" secondItem="Nte-GU-lcs" secondAttribute="centerX" id="4c4-08-Q3E"/>
-                            <constraint firstItem="f9F-UN-SBB" firstAttribute="leading" secondItem="N3U-wn-qIB" secondAttribute="leading" constant="15" id="BGq-ba-KTT"/>
+                            <constraint firstItem="f9F-UN-SBB" firstAttribute="leading" secondItem="N3U-wn-qIB" secondAttribute="leading" constant="10" id="BGq-ba-KTT"/>
                             <constraint firstItem="cmq-pv-rzu" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="N3U-wn-qIB" secondAttribute="leading" constant="10" id="D5W-KC-TXU"/>
-                            <constraint firstItem="Nrb-rx-Yye" firstAttribute="leading" secondItem="N3U-wn-qIB" secondAttribute="leading" constant="15" id="Fzr-zf-UPl"/>
+                            <constraint firstItem="Nrb-rx-Yye" firstAttribute="leading" secondItem="N3U-wn-qIB" secondAttribute="leading" constant="10" id="Fzr-zf-UPl"/>
                             <constraint firstItem="nvI-yU-Zsg" firstAttribute="leading" secondItem="N3U-wn-qIB" secondAttribute="leading" id="Jbn-5s-xMu"/>
                             <constraint firstItem="Nrb-rx-Yye" firstAttribute="centerX" secondItem="Nte-GU-lcs" secondAttribute="centerX" id="OHH-6a-fLT"/>
-                            <constraint firstItem="N3U-wn-qIB" firstAttribute="bottom" secondItem="f9F-UN-SBB" secondAttribute="bottom" constant="10" id="Qr7-Ic-w2x"/>
+                            <constraint firstItem="N3U-wn-qIB" firstAttribute="bottom" secondItem="f9F-UN-SBB" secondAttribute="bottom" id="Qr7-Ic-w2x"/>
                             <constraint firstItem="EYT-MJ-Tsu" firstAttribute="centerX" secondItem="Nte-GU-lcs" secondAttribute="centerX" id="TX0-xy-3V7"/>
                             <constraint firstItem="cmq-pv-rzu" firstAttribute="centerX" secondItem="Nte-GU-lcs" secondAttribute="centerX" id="UH9-C2-A2C"/>
                             <constraint firstItem="f9F-UN-SBB" firstAttribute="top" secondItem="Nrb-rx-Yye" secondAttribute="bottom" constant="10" id="Zwm-gD-mpa"/>

--- a/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
+++ b/TodayAnbu/Sources/Controllers/CallCheckViewController.swift
@@ -49,6 +49,8 @@ extension CallCheckViewController {
         memoView.delegate = self
     }
     func configureButtons() {
+        callDoneButton.layer.cornerRadius = 5
+        callFailButton.layer.cornerRadius = 5
         callDoneButton.addTarget(self, action: #selector(onTapDoneButton), for: .touchUpInside)
         callFailButton.addTarget(self, action: #selector(onTapFailButton), for: .touchUpInside)
     }

--- a/TodayAnbu/Sources/Controllers/DadInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/DadInitViewController.swift
@@ -88,7 +88,7 @@ class DadInitViewController: UIViewController, UITextFieldDelegate {
 
         dadDayVstack.isHidden = true
         startButton.isEnabled = false
-        startButton.layer.cornerRadius = 10
+        startButton.layer.cornerRadius = 5
 
         // 7개 알람 버튼 레이아웃 설정
         setHStackViewDefaultConstraints()

--- a/TodayAnbu/Sources/Controllers/MomInitViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MomInitViewController.swift
@@ -92,7 +92,7 @@ class MomInitViewController: UIViewController, UITextFieldDelegate {
 
         momDayVstack.isHidden = true
         startButton.isEnabled = false
-        startButton.layer.cornerRadius = 10
+        startButton.layer.cornerRadius = 5
 
         // 7개 알람 버튼 레이아웃 설정
         setHStackViewDefaultConstraints()


### PR DESCRIPTION
## 개요

- 버튼들의 레이아웃이 맞지 않는 것을 수정했습니다.

<br/>

## 작업사항
### 작업 사항


- Main Storyboard의 AutoLayout을 수정했습니다.

### References
- 없음

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)


<p align="left">
<img width="200" alt="스크린샷 2022-08-02 오전 10 22 40" src="https://user-images.githubusercontent.com/81943525/182271740-3e2f89c8-002a-428f-a059-34e51d313193.png">
<img width="200" alt="스크린샷 2022-08-02 오전 10 22 35" src="https://user-images.githubusercontent.com/81943525/182271734-43e44918-4d6a-42da-b37e-30346aed5c07.png">
<img width="200" alt="스크린샷 2022-08-02 오전 10 22 40" src="https://user-images.githubusercontent.com/81943525/182271841-9f9b07a8-167f-4f22-9b39-4405da6901d9.png">
</p>


<br/>

## 그외
### 리뷰 포인트
- bottom -> safe area
- leading -> safe area + 10
- aspect ratio 6:1 (가로, 세로 비율 6:1)


### 진행 예정 사항

- [ ] 버튼 로직 구현 제발
