### PR TITLE
Fix/157 design detail revision

### DIFF
--- a/TodayAnbu.xcodeproj/project.pbxproj
+++ b/TodayAnbu.xcodeproj/project.pbxproj
@@ -646,7 +646,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -679,7 +679,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbu/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -710,7 +710,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3WVLC7Y373;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbuWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TodayAnbuWidget;
@@ -738,7 +738,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3WVLC7Y373;
+				DEVELOPMENT_TEAM = YYP248S73Y;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TodayAnbuWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TodayAnbuWidget;

--- a/TodayAnbu/Sources/Boards/MemoStoryboard.storyboard
+++ b/TodayAnbu/Sources/Boards/MemoStoryboard.storyboard
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LNM-k1-Gzb">
-                                <rect key="frame" x="0.0" y="0.0" width="428" height="150"/>
+                                <rect key="frame" x="0.0" y="0.0" width="428" height="120"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="어떤 대화를 했을까요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fgd-qA-dbA">
-                                        <rect key="frame" x="104.66666666666669" y="67.666666666666671" width="219" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대화 메모" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fgd-qA-dbA">
+                                        <rect key="frame" x="168" y="60" width="92" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -31,17 +31,17 @@
                                 <color key="backgroundColor" name="mainIndigo"/>
                                 <constraints>
                                     <constraint firstItem="fgd-qA-dbA" firstAttribute="centerX" secondItem="LNM-k1-Gzb" secondAttribute="centerX" id="Uvt-OV-aEi"/>
-                                    <constraint firstItem="fgd-qA-dbA" firstAttribute="centerY" secondItem="LNM-k1-Gzb" secondAttribute="centerY" multiplier="1.1" id="g5z-wM-9A2"/>
-                                    <constraint firstAttribute="height" constant="150" id="k23-sg-Qnw"/>
+                                    <constraint firstAttribute="height" constant="120" id="k23-sg-Qnw"/>
+                                    <constraint firstAttribute="bottom" secondItem="fgd-qA-dbA" secondAttribute="bottom" constant="30" id="xAC-lZ-GhQ"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="15"/>
+                                        <integer key="value" value="0"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="500" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="dk1-Wv-mzr">
-                                <rect key="frame" x="0.0" y="150" width="428" height="742"/>
+                                <rect key="frame" x="0.0" y="181" width="428" height="711"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="fsy-oG-6wO">
                                     <size key="itemSize" width="180" height="225"/>
@@ -61,18 +61,18 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="180" height="195"/>
                                                     <color key="backgroundColor" name="memoColor"/>
                                                 </view>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k6r-8K-oVl" userLabel="Day">
-                                                    <rect key="frame" x="10" y="202" width="160" height="18"/>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                                    <nil key="textColor"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k6r-8K-oVl" userLabel="Day">
+                                                    <rect key="frame" x="10" y="200.66666666666666" width="150" height="14.333333333333343"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                    <color key="textColor" red="0.36714565576881392" green="0.38528324485670107" blue="0.20265447418691659" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="myLabel" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YPr-Pi-ddu">
-                                                    <rect key="frame" x="15" y="14.999999999999998" width="150" height="28.333333333333329"/>
+                                                    <rect key="frame" x="15" y="15.000000000000002" width="150" height="26.666666666666671"/>
                                                     <attributedString key="attributedText">
                                                         <fragment content="Description">
                                                             <attributes>
-                                                                <font key="NSFont" size="18" name="AppleSDGothicNeo-Medium"/>
+                                                                <font key="NSFont" size="17" name="AppleSDGothicNeo-Medium"/>
                                                                 <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineHeightMultiple="1.3" tighteningFactorForTruncation="0.0"/>
                                                             </attributes>
                                                         </fragment>
@@ -80,12 +80,12 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                            <color key="backgroundColor" name="memoColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="YPr-Pi-ddu" secondAttribute="trailing" constant="15" id="1Hy-V0-bqG"/>
                                                 <constraint firstItem="Q5Y-z8-5tO" firstAttribute="leading" secondItem="53a-cf-Jfb" secondAttribute="leading" id="2C4-qm-r8r"/>
-                                                <constraint firstAttribute="trailing" secondItem="k6r-8K-oVl" secondAttribute="trailing" constant="10" id="9zp-a3-i8u"/>
-                                                <constraint firstAttribute="bottom" secondItem="k6r-8K-oVl" secondAttribute="bottom" constant="5" id="EfV-Ta-DBl"/>
+                                                <constraint firstAttribute="trailing" secondItem="k6r-8K-oVl" secondAttribute="trailing" constant="20" id="9zp-a3-i8u"/>
+                                                <constraint firstAttribute="bottom" secondItem="k6r-8K-oVl" secondAttribute="bottom" constant="10" id="EfV-Ta-DBl"/>
                                                 <constraint firstItem="YPr-Pi-ddu" firstAttribute="leading" secondItem="53a-cf-Jfb" secondAttribute="leading" constant="15" id="QXD-E8-0jT"/>
                                                 <constraint firstAttribute="trailing" secondItem="Q5Y-z8-5tO" secondAttribute="trailing" id="YDs-7S-PKL"/>
                                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="YPr-Pi-ddu" secondAttribute="bottom" constant="30" id="YOk-xq-VfD"/>
@@ -103,16 +103,23 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
+                            <searchBar contentMode="redraw" searchBarStyle="minimal" text="" placeholder="찾고 싶은 키워드를 입력해보세요!" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ump-AJ-ndm">
+                                <rect key="frame" x="15" y="130" width="398" height="51"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="top" secondItem="LNM-k1-Gzb" secondAttribute="top" id="0KS-6E-ktr"/>
-                            <constraint firstItem="dk1-Wv-mzr" firstAttribute="top" secondItem="LNM-k1-Gzb" secondAttribute="bottom" id="HPS-t4-3oa"/>
+                            <constraint firstItem="ump-AJ-ndm" firstAttribute="trailing" secondItem="LNM-k1-Gzb" secondAttribute="trailing" constant="-15" id="2gJ-5C-F0i"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="dk1-Wv-mzr" secondAttribute="bottom" id="IYi-Rs-cxt"/>
+                            <constraint firstItem="ump-AJ-ndm" firstAttribute="leading" secondItem="LNM-k1-Gzb" secondAttribute="leading" constant="15" id="Xb9-8n-ZZl"/>
                             <constraint firstItem="LNM-k1-Gzb" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="eoz-Lb-c64"/>
+                            <constraint firstItem="dk1-Wv-mzr" firstAttribute="top" secondItem="ump-AJ-ndm" secondAttribute="bottom" id="gE4-av-40D"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="dk1-Wv-mzr" secondAttribute="trailing" id="hKY-L1-eUw"/>
                             <constraint firstItem="dk1-Wv-mzr" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="qSf-5m-BZm"/>
+                            <constraint firstItem="ump-AJ-ndm" firstAttribute="top" secondItem="LNM-k1-Gzb" secondAttribute="bottom" constant="10" id="to2-Tj-Ddu"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="LNM-k1-Gzb" secondAttribute="trailing" id="zg4-Ob-aWe"/>
                         </constraints>
                     </view>
@@ -127,16 +134,13 @@
     </scenes>
     <resources>
         <namedColor name="mainIndigo">
-            <color red="0.15686274509803921" green="0.20000000000000001" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.15700000524520874" green="0.20000000298023224" blue="0.58799999952316284" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="memoColor">
-            <color red="0.99199998378753662" green="0.99199998378753662" blue="0.58799999952316284" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.99215686274509807" green="0.99215686274509807" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/TodayAnbu/Sources/Boards/MemoStoryboard.storyboard
+++ b/TodayAnbu/Sources/Boards/MemoStoryboard.storyboard
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="428" height="120"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="대화 메모" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fgd-qA-dbA">
-                                        <rect key="frame" x="168" y="60" width="92" height="30"/>
+                                        <rect key="frame" x="168" y="65" width="92" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -32,7 +32,7 @@
                                 <constraints>
                                     <constraint firstItem="fgd-qA-dbA" firstAttribute="centerX" secondItem="LNM-k1-Gzb" secondAttribute="centerX" id="Uvt-OV-aEi"/>
                                     <constraint firstAttribute="height" constant="120" id="k23-sg-Qnw"/>
-                                    <constraint firstAttribute="bottom" secondItem="fgd-qA-dbA" secondAttribute="bottom" constant="30" id="xAC-lZ-GhQ"/>
+                                    <constraint firstAttribute="bottom" secondItem="fgd-qA-dbA" secondAttribute="bottom" constant="25" id="xAC-lZ-GhQ"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -40,7 +40,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="500" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="dk1-Wv-mzr">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="500" restorationIdentifier="ReUseCell" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="dk1-Wv-mzr">
                                 <rect key="frame" x="0.0" y="181" width="428" height="711"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="fsy-oG-6wO">
@@ -50,7 +50,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="top" reuseIdentifier="MemoCell" id="wU4-wy-NO9" customClass="MemoCell" customModule="TodayAnbu" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="top" restorationIdentifier="cellRegister" reuseIdentifier="MemoCell" id="wU4-wy-NO9" customClass="MemoCell" customModule="TodayAnbu" customModuleProvider="target" colorLabel="IBBuiltInLabel-Red">
                                         <rect key="frame" x="0.0" y="0.0" width="180" height="225"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="53a-cf-Jfb">
@@ -125,6 +125,7 @@
                     </view>
                     <connections>
                         <outlet property="collectionView" destination="dk1-Wv-mzr" id="8jK-S9-iyl"/>
+                        <outlet property="searchBar" destination="ump-AJ-ndm" id="sqM-C2-DRj"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/TodayAnbu/Sources/Boards/MemoStoryboard.storyboard
+++ b/TodayAnbu/Sources/Boards/MemoStoryboard.storyboard
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LNM-k1-Gzb">
-                                <rect key="frame" x="0.0" y="0.0" width="428" height="172"/>
+                                <rect key="frame" x="0.0" y="0.0" width="428" height="150"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="자신이 남긴 메모를 확인해보세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fgd-qA-dbA">
-                                        <rect key="frame" x="54.666666666666657" y="71" width="319" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="어떤 대화를 했을까요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fgd-qA-dbA">
+                                        <rect key="frame" x="104.66666666666669" y="67.666666666666671" width="219" height="30"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                         <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -31,17 +31,17 @@
                                 <color key="backgroundColor" name="mainIndigo"/>
                                 <constraints>
                                     <constraint firstItem="fgd-qA-dbA" firstAttribute="centerX" secondItem="LNM-k1-Gzb" secondAttribute="centerX" id="Uvt-OV-aEi"/>
-                                    <constraint firstItem="fgd-qA-dbA" firstAttribute="centerY" secondItem="LNM-k1-Gzb" secondAttribute="centerY" id="g5z-wM-9A2"/>
-                                    <constraint firstAttribute="height" constant="172" id="k23-sg-Qnw"/>
+                                    <constraint firstItem="fgd-qA-dbA" firstAttribute="centerY" secondItem="LNM-k1-Gzb" secondAttribute="centerY" multiplier="1.1" id="g5z-wM-9A2"/>
+                                    <constraint firstAttribute="height" constant="150" id="k23-sg-Qnw"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="10"/>
+                                        <integer key="value" value="15"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="500" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="dk1-Wv-mzr">
-                                <rect key="frame" x="0.0" y="172" width="428" height="720"/>
+                                <rect key="frame" x="0.0" y="150" width="428" height="742"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="fsy-oG-6wO">
                                     <size key="itemSize" width="180" height="225"/>
@@ -130,7 +130,7 @@
             <color red="0.15686274509803921" green="0.20000000000000001" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="memoColor">
-            <color red="0.99215686274509807" green="0.99215686274509807" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.99199998378753662" green="0.99199998378753662" blue="0.58799999952316284" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -75,20 +75,40 @@ class MainViewController: UIViewController {
 
     private let topArea: UIView = {
         let area = UIView()
-        area.layer.cornerRadius = 20
+        area.layer.cornerRadius = 15
         area.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         area.backgroundColor = .mainIndigo
         return area
     }()
-    private let topTitle: UILabel = {
+
+    lazy private var topTitle: UIStackView = {
+        let titleHStack = UIStackView()
+        titleHStack.axis = .horizontal
+        titleHStack.spacing = 10
+        titleHStack.addArrangedSubview(topTitleFirstLabel)
+        titleHStack.addArrangedSubview(topTitleDays)
+        titleHStack.addArrangedSubview(topTitleSecondLabel)
+        return titleHStack
+    }()
+
+    private let topTitleFirstLabel: UILabel = {
         let label = UILabel()
         let dayLabel = UILabel()
         label.textColor = .mainTitleFontColor
-        label.text = "전화한지             되었어요"
+        label.text = "전화한지"
         label.font = .boldSystemFont(ofSize: 25)
-
         return label
     }()
+
+    private let topTitleSecondLabel: UILabel = {
+        let label = UILabel()
+        let dayLabel = UILabel()
+        label.textColor = .mainTitleFontColor
+        label.text = "되었어요"
+        label.font = .boldSystemFont(ofSize: 25)
+        return label
+    }()
+
     private func topTitleDays(notCalledDate: Int) -> UILabel {
         let label = UILabel()
         label.text = "\(notCalledDate)일"
@@ -96,6 +116,7 @@ class MainViewController: UIViewController {
         label.font = .boldSystemFont(ofSize: 27)
         return label
     }
+
     private lazy var topTitleDays = topTitleDays(notCalledDate: self.notCalledDate)
 
     private let weeklyAnbuLabel: UILabel = {
@@ -105,6 +126,7 @@ class MainViewController: UIViewController {
         label.textColor = .white
         return label
     }()
+
     private lazy var settingButton: UIButton = {
         let setButton = UIButton()
         setButton.setImage(UIImage(systemName: "gearshape.fill"), for: UIControl.State.normal)
@@ -113,6 +135,7 @@ class MainViewController: UIViewController {
         setButton.addTarget(self, action: #selector(setButtonAction(_:)), for: .touchUpInside)
         return setButton
     }()
+
     private let momLabel: UILabel = {
         let label = UILabel()
         label.text = "어머니"
@@ -120,6 +143,7 @@ class MainViewController: UIViewController {
         label.textColor = .white
         return label
     }()
+
     private let dadLabel: UILabel = {
         let label = UILabel()
         label.text = "아버지"
@@ -127,6 +151,7 @@ class MainViewController: UIViewController {
         label.textColor = .white
         return label
     }()
+
     private func momGauge(momCheckCount: Int, gaugeColor: UIColor!) -> UIView {
         let capsule = UIView()
         capsule.layer.cornerRadius = 10
@@ -291,7 +316,6 @@ class MainViewController: UIViewController {
     private func configureAddSubView() {
         view.addSubview(topArea)
         view.addSubview(topTitle)
-        view.addSubview(topTitleDays)
         view.addSubview(weeklyAnbuLabel)
         view.addSubview(momLabel)
         view.addSubview(dadLabel)
@@ -343,10 +367,7 @@ class MainViewController: UIViewController {
             topTitle.leadingAnchor.constraint(equalTo: topArea.leadingAnchor, constant: 20),
             topTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20)
         ])
-        NSLayoutConstraint.activate([
-            topTitleDays.trailingAnchor.constraint(equalTo: topArea.trailingAnchor, constant: -220),
-            topTitleDays.bottomAnchor.constraint(equalTo: topTitle.bottomAnchor)
-        ])
+
         NSLayoutConstraint.activate([
             settingButton.centerYAnchor.constraint(equalTo: topTitle.centerYAnchor),
             settingButton.widthAnchor.constraint(equalToConstant: 40),
@@ -354,7 +375,7 @@ class MainViewController: UIViewController {
         ])
         NSLayoutConstraint.activate([
             weeklyAnbuLabel.leadingAnchor.constraint(equalTo: topArea.leadingAnchor, constant: 20),
-            weeklyAnbuLabel.topAnchor.constraint(equalTo: topTitle.topAnchor, constant: 60)
+            weeklyAnbuLabel.topAnchor.constraint(equalTo: topTitle.topAnchor, constant: 50)
         ])
         NSLayoutConstraint.activate([
             momLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
@@ -401,7 +422,7 @@ class MainViewController: UIViewController {
             dadGauge3.trailingAnchor.constraint(equalTo: dadGauge3.leadingAnchor, constant: 75)
         ])
         NSLayoutConstraint.activate([
-            topicSegmentedControl.topAnchor.constraint(equalTo: topArea.bottomAnchor, constant: 50),
+            topicSegmentedControl.topAnchor.constraint(equalTo: topArea.bottomAnchor, constant: 30),
             topicSegmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             topicSegmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30)
         ])
@@ -429,7 +450,7 @@ class MainViewController: UIViewController {
             callButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 5),
             callButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -5),
             callButton.heightAnchor.constraint(equalToConstant: 55),
-            callButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -50)
+            callButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
         ])
     }
 

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -56,15 +56,16 @@ class MainViewController: UIViewController {
             configureAll()
         }
     }
+
     lazy var dadCheckCount: Int = 0 {
         didSet {
             switch dadCheckCount {
             case 1:
-                dadGauge1 = dadGauge(dadCheckCount: 1, gaugeColor: .dadGaugeLight)
+                dadGauge1 = dadGauge(dadCheckCount: 1, gaugeColor: .systemPurple)
             case 2:
-                dadGauge2 = dadGauge(dadCheckCount: 2, gaugeColor: .dadGaugeLight)
+                dadGauge2 = dadGauge(dadCheckCount: 2, gaugeColor: .systemPurple)
             case 3:
-                dadGauge3 = dadGauge(dadCheckCount: 3, gaugeColor: .dadGaugeLight)
+                dadGauge3 = dadGauge(dadCheckCount: 3, gaugeColor: .systemPurple)
             default:
                 print("")
             }
@@ -100,7 +101,7 @@ class MainViewController: UIViewController {
     private let weeklyAnbuLabel: UILabel = {
         let label = UILabel()
         label.text = "이번주 안부"
-        label.font = .systemFont(ofSize: 25, weight: .semibold)
+        label.font = .systemFont(ofSize: 26, weight: .heavy)
         label.textColor = .white
         return label
     }()
@@ -146,20 +147,22 @@ class MainViewController: UIViewController {
     private lazy var dadGauge2 = dadGauge(dadCheckCount: 2, gaugeColor: .dadGaugeDeep)
     private lazy var dadGauge3 = dadGauge(dadCheckCount: 3, gaugeColor: .dadGaugeDeep)
 
-    private let topicLabel: UILabel = {
-        let topicText = UILabel()
-        topicText.font = .systemFont(ofSize: 20, weight: .semibold)
-        return topicText
-    }()
     private lazy var topicSegmentedControl: UISegmentedControl = {
         let segmentItems = ["가벼운 토픽", "진지한 토픽"]
         let topicSegmentedControl = UISegmentedControl(items: segmentItems)
+
         topicSegmentedControl.selectedSegmentIndex = 0
-        topicSegmentedControl.backgroundColor = .systemGray3
         topicSegmentedControl.tintColor = .black
         topicSegmentedControl.addTarget(self, action: #selector(segmentedValueChanged(_:)), for: .valueChanged)
         return topicSegmentedControl
     }()
+
+    private let topicLabel: UILabel = {
+        let topicText = UILabel()
+        topicText.font = .systemFont(ofSize: 24, weight: .semibold)
+        return topicText
+    }()
+
     private lazy var refreshButton: UIButton = {
             let refreshButton = UIButton(type: UIButton.ButtonType.system)
             refreshButton.setImage(UIImage(systemName: "goforward"), for: UIControl.State.normal)
@@ -177,7 +180,6 @@ class MainViewController: UIViewController {
         topicTableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
         topicTableView.reloadData()
         topicTableView.layer.cornerRadius = 10
-        topicTableView.backgroundColor = .black
         topicTableView.isScrollEnabled = false
         return topicTableView
     }()
@@ -262,14 +264,6 @@ class MainViewController: UIViewController {
             }
         }
         self.navigationController?.setToolbarHidden(true, animated: true)
-
-//        let currentTime =  Date.currentNumericLocalizedDateTime
-//        guard let callTime = UserDefaults.standard.string(forKey: "lastCallTime") else {
-//            self.notCalledDate = 0
-//            UserDefaults.standard.set(Date.currentNumericLocalizedDateTime, forKey: "lastCallTime")
-//            return
-//        }
-//        self.notCalledDate = Date.dayDifference(callTime, currentTime) ?? 0
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -347,7 +341,7 @@ class MainViewController: UIViewController {
         ])
         NSLayoutConstraint.activate([
             topTitle.leadingAnchor.constraint(equalTo: topArea.leadingAnchor, constant: 20),
-            topTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10)
+            topTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20)
         ])
         NSLayoutConstraint.activate([
             topTitleDays.trailingAnchor.constraint(equalTo: topArea.trailingAnchor, constant: -220),
@@ -413,21 +407,21 @@ class MainViewController: UIViewController {
         ])
 
         NSLayoutConstraint.activate([
-            topicLabel.leadingAnchor.constraint(equalTo: topicSegmentedControl.leadingAnchor),
-            topicLabel.topAnchor.constraint(equalTo: topicSegmentedControl.bottomAnchor, constant: 35)
+            topicLabel.leadingAnchor.constraint(equalTo: topicSegmentedControl.leadingAnchor, constant: 15),
+            topicLabel.topAnchor.constraint(equalTo: topicSegmentedControl.bottomAnchor, constant: 20)
         ])
 
         NSLayoutConstraint.activate([
             refreshButton.heightAnchor.constraint(equalToConstant: 32),
             refreshButton.widthAnchor.constraint(equalToConstant: 32),
             refreshButton.trailingAnchor.constraint(equalTo: topicSegmentedControl.trailingAnchor),
-            refreshButton.topAnchor.constraint(equalTo: topicLabel.topAnchor)
+            refreshButton.topAnchor.constraint(equalTo: topicSegmentedControl.bottomAnchor, constant: 17)
         ])
 
         NSLayoutConstraint.activate([
-            topicTableView.topAnchor.constraint(equalTo: topicLabel.bottomAnchor, constant: 30),
+            topicTableView.topAnchor.constraint(equalTo: topicLabel.bottomAnchor, constant: 20),
             topicTableView.heightAnchor.constraint(equalToConstant: 150),
-            topicTableView.leadingAnchor.constraint(equalTo: topicLabel.leadingAnchor),
+            topicTableView.leadingAnchor.constraint(equalTo: topicSegmentedControl.leadingAnchor),
             topicTableView.trailingAnchor.constraint(equalTo: refreshButton.trailingAnchor)
         ])
 
@@ -460,7 +454,7 @@ class MainViewController: UIViewController {
 
         func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
             let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-            cell.backgroundColor = .systemGray5
+            cell.backgroundColor = .systemGray6
             cell.textLabel?.text = topics[indexPath.row]
             cell.textLabel?.numberOfLines = 2
             return cell
@@ -484,7 +478,6 @@ extension MainViewController {
                 UIApplication.shared.openURL(openApp)
             }
         }
-
         // 스키마명을 사용해 외부앱 실행이 불가능한 경우
         else {
             print("[goDeviceApp : 디바이스 외부 앱 열기 실패]")
@@ -536,11 +529,11 @@ extension MainViewController {
         case 0:
             topics = genericTopics[genericTopicIndex]
             topicLabel.text = topics.last
-            topicLabel.font = .systemFont(ofSize: 20, weight: .semibold)
+            topicLabel.font = .systemFont(ofSize: 24, weight: .semibold)
         default:
             topics = seriousTopics[seriousTopicIndex]
             topicLabel.text = topics.last
-            topicLabel.font = .systemFont(ofSize: 20, weight: .semibold)
+            topicLabel.font = .systemFont(ofSize: 24, weight: .semibold)
         }
         topicTableView.reloadData()
     }

--- a/TodayAnbu/Sources/Controllers/MainViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MainViewController.swift
@@ -538,10 +538,7 @@ extension MainViewController {
     }
 
     @objc private func setButtonAction(_: UIButton!) {
-        // navigationController?.pushViewController(SettingViewController(), animated: true)
         let settingViewControllerNavigation = UINavigationController(rootViewController: SettingViewController())
-        // UINavigationController(rootViewController: MemoDetailViewController())
-        // settingViewControllerNavigation.modalPresentationStyle = UIModalPresentationStyle.fullScreen
         present(settingViewControllerNavigation, animated: true, completion: nil)
     }
 

--- a/TodayAnbu/Sources/Controllers/MemoDetailViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MemoDetailViewController.swift
@@ -24,7 +24,7 @@ class MemoDetailViewController: UIViewController {
     private let memoDate: UILabel = {
         let label = UILabel()
         label.text = "7월 11일"
-        label.font = .boldSystemFont(ofSize: 25)
+        label.font = .boldSystemFont(ofSize: 16)
         label.textColor = .black
         return label
     }()
@@ -41,7 +41,7 @@ class MemoDetailViewController: UIViewController {
         let memoDates = [String](dict.keys)
         let memoDescription = [String](dict.values)
         label.text = memoDescription[0]
-        label.font = .systemFont(ofSize: 18)
+        label.font = .systemFont(ofSize: 16)
         label.textColor = .black
         label.numberOfLines = 0
         return label

--- a/TodayAnbu/Sources/Controllers/MemoViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MemoViewController.swift
@@ -18,7 +18,7 @@ class MemoViewController: UIViewController {
     }
 
     var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
-    // var list: [MemoData] = MemoData.list
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         searchBar.delegate = self
@@ -58,6 +58,7 @@ class MemoViewController: UIViewController {
         section.interGroupSpacing = spacing
         return UICollectionViewCompositionalLayout(section: section)
     }
+    
     func makeMemoList() -> [MemoData] {
         var list: [MemoData] = []
         var dict: [String: String] = [:]
@@ -77,13 +78,14 @@ class MemoViewController: UIViewController {
 extension MemoViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // let list: [MemoData] = makeMemoList()
-        let framework = list[indexPath.item]
+        _ = list[indexPath.item]
         // navigationController?.pushViewController(SettingViewController(), animated: true)
     }
 }
 
 extension MemoViewController: UISearchBarDelegate {
     
+    // MARK: - searchText 변화시 호출되는 함수
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         if searchText.isEmpty {
             searchBar.delegate = self
@@ -121,15 +123,15 @@ extension MemoViewController: UISearchBarDelegate {
             snapshot.appendSections([.main])
             snapshot.appendItems(list, toSection: .main)
             dataSource.apply(snapshot)
-
-            // MARK: - layer
             collectionView.collectionViewLayout = layout()
             
+            // MARK: - 검색어를 포함하는 메모리스트를 반환
             func makeFilteredMemoList() -> [MemoData] {
                 var list: [MemoData] = []
                 var dict: [String: String] = [:]
                 dict = UserDefaults.standard.value(forKey: "momMemo") as? [String: String] ?? [:]
                 let memoDates = [String](dict.keys)
+                // MARK: - 검색어를 포함하는 메모 추출
                 let memoDescription = [String](dict.values).filter({$0.contains(searchText)})
                 let memoCount: Int = memoDescription.count
                 for idx in 0 ..< memoCount {
@@ -142,6 +144,7 @@ extension MemoViewController: UISearchBarDelegate {
         }
     }
     
+    // MARK: - 검색 버튼 클릭시, 키보드 dismiss
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         self.searchBar.endEditing(true)
     }

--- a/TodayAnbu/Sources/Controllers/MemoViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MemoViewController.swift
@@ -28,7 +28,7 @@ class MemoViewController: UIViewController {
                 return nil
             }
             cell.configure(item)
-            cell.layer.cornerRadius = 15
+            cell.layer.cornerRadius = 25
             cell.layer.shadowOffset = CGSize(width: 5, height: 5)
             return cell
         })

--- a/TodayAnbu/Sources/Controllers/MemoViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MemoViewController.swift
@@ -18,7 +18,6 @@ class MemoViewController: UIViewController {
     }
 
     var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         searchBar.delegate = self
@@ -58,7 +57,6 @@ class MemoViewController: UIViewController {
         section.interGroupSpacing = spacing
         return UICollectionViewCompositionalLayout(section: section)
     }
-    
     func makeMemoList() -> [MemoData] {
         var list: [MemoData] = []
         var dict: [String: String] = [:]
@@ -73,7 +71,6 @@ class MemoViewController: UIViewController {
         }
         return list
     }
-    
 }
 extension MemoViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -84,7 +81,6 @@ extension MemoViewController: UICollectionViewDelegate {
 }
 
 extension MemoViewController: UISearchBarDelegate {
-    
     // MARK: - searchText 변화시 호출되는 함수
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         if searchText.isEmpty {
@@ -100,7 +96,6 @@ extension MemoViewController: UISearchBarDelegate {
                 cell.layer.shadowOffset = CGSize(width: 5, height: 5)
                 return cell
             })
-            
             var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
             snapshot.appendSections([.main])
             snapshot.appendItems(list, toSection: .main)
@@ -124,7 +119,6 @@ extension MemoViewController: UISearchBarDelegate {
             snapshot.appendItems(list, toSection: .main)
             dataSource.apply(snapshot)
             collectionView.collectionViewLayout = layout()
-            
             // MARK: - 검색어를 포함하는 메모리스트를 반환
             func makeFilteredMemoList() -> [MemoData] {
                 var list: [MemoData] = []
@@ -143,11 +137,8 @@ extension MemoViewController: UISearchBarDelegate {
             }
         }
     }
-    
     // MARK: - 검색 버튼 클릭시, 키보드 dismiss
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         self.searchBar.endEditing(true)
     }
 }
-
-

--- a/TodayAnbu/Sources/Controllers/MemoViewController.swift
+++ b/TodayAnbu/Sources/Controllers/MemoViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 
 class MemoViewController: UIViewController {
 
-    @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var searchBar: UISearchBar!
+    @IBOutlet var collectionView: UICollectionView!
     var list: [MemoData] = []
     typealias Item = MemoData
     enum Section {
@@ -20,6 +21,7 @@ class MemoViewController: UIViewController {
     // var list: [MemoData] = MemoData.list
     override func viewDidLoad() {
         super.viewDidLoad()
+        searchBar.delegate = self
         list = makeMemoList()
         collectionView.delegate = self
         // MARK: - presentation
@@ -52,7 +54,7 @@ class MemoViewController: UIViewController {
         groupLayout.interItemSpacing = .fixed(spacing)
         // Section
         let section = NSCollectionLayoutSection(group: groupLayout)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 25, leading: 25, bottom: 0, trailing: 25)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 25, bottom: 0, trailing: 25)
         section.interGroupSpacing = spacing
         return UICollectionViewCompositionalLayout(section: section)
     }
@@ -70,6 +72,7 @@ class MemoViewController: UIViewController {
         }
         return list
     }
+    
 }
 extension MemoViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -78,3 +81,70 @@ extension MemoViewController: UICollectionViewDelegate {
         // navigationController?.pushViewController(SettingViewController(), animated: true)
     }
 }
+
+extension MemoViewController: UISearchBarDelegate {
+    
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        if searchText.isEmpty {
+            searchBar.delegate = self
+            list = makeMemoList()
+            collectionView.delegate = self
+            dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MemoCell", for: indexPath) as? MemoCell else {
+                    return nil
+                }
+                cell.configure(item)
+                cell.layer.cornerRadius = 25
+                cell.layer.shadowOffset = CGSize(width: 5, height: 5)
+                return cell
+            })
+            
+            var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+            snapshot.appendSections([.main])
+            snapshot.appendItems(list, toSection: .main)
+            dataSource.apply(snapshot)
+            collectionView.collectionViewLayout = layout()
+        } else {
+            searchBar.delegate = self
+            list = makeFilteredMemoList()
+            collectionView.delegate = self
+            dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MemoCell", for: indexPath) as? MemoCell else {
+                    return nil
+                }
+                cell.configure(item)
+                cell.layer.cornerRadius = 25
+                cell.layer.shadowOffset = CGSize(width: 5, height: 5)
+                return cell
+            })
+            var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+            snapshot.appendSections([.main])
+            snapshot.appendItems(list, toSection: .main)
+            dataSource.apply(snapshot)
+
+            // MARK: - layer
+            collectionView.collectionViewLayout = layout()
+            
+            func makeFilteredMemoList() -> [MemoData] {
+                var list: [MemoData] = []
+                var dict: [String: String] = [:]
+                dict = UserDefaults.standard.value(forKey: "momMemo") as? [String: String] ?? [:]
+                let memoDates = [String](dict.keys)
+                let memoDescription = [String](dict.values).filter({$0.contains(searchText)})
+                let memoCount: Int = memoDescription.count
+                for idx in 0 ..< memoCount {
+                    let strArray = Array(memoDates[idx])
+                    let dateString = "\(strArray[2])\(strArray[3])월 \(strArray[4])\(strArray[5])일"
+                    list.append(MemoData(date: String(dateString), description: memoDescription[idx]))
+                }
+                return list
+            }
+        }
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        self.searchBar.endEditing(true)
+    }
+}
+
+

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -143,7 +143,6 @@ class SettingViewController: UIViewController {
 
     @objc func doneButtonAction(_ sender: UIButton!) {
         self.dismiss(animated: true)
-        print("dismiss")
     }
 
     func removeLocalNotifications() {

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -32,7 +32,8 @@ class SettingViewController: UIViewController {
         tabBarController?.tabBar.isHidden = true
     }
 
-    func configureViewComponent() {        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(doneButtonAction(_:)))
+    func configureViewComponent() {
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(doneButtonAction(_:)))
 
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false

--- a/TodayAnbu/Sources/Controllers/SettingViewController.swift
+++ b/TodayAnbu/Sources/Controllers/SettingViewController.swift
@@ -21,7 +21,6 @@ class SettingViewController: UIViewController {
         label.textColor = .systemGray
         return label
     }()
-
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,7 +32,8 @@ class SettingViewController: UIViewController {
         tabBarController?.tabBar.isHidden = true
     }
 
-    func configureViewComponent() {
+    func configureViewComponent() {        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(doneButtonAction(_:)))
+
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
@@ -139,6 +139,11 @@ class SettingViewController: UIViewController {
                 }
             }
         }
+    }
+
+    @objc func doneButtonAction(_ sender: UIButton!) {
+        self.dismiss(animated: true)
+        print("dismiss")
     }
 
     func removeLocalNotifications() {

--- a/TodayAnbu/Sources/Controllers/TabBarController.swift
+++ b/TodayAnbu/Sources/Controllers/TabBarController.swift
@@ -15,9 +15,12 @@ class TabBarController: UITabBarController {
 
         let secondTab = UIStoryboard(name: "MemoStoryboard", bundle: nil).instantiateViewController(withIdentifier: "MemoViewController")
 
+        firstTab.tabBarItem.title = "안부"
         firstTab.tabBarItem.image = UIImage(systemName: "house")
         firstTab.tabBarItem.selectedImage = UIImage(systemName: "house.fill")
         firstTab.isNavigationBarHidden = true
+
+        secondTab.tabBarItem.title = "메모"
         secondTab.tabBarItem.image = UIImage(systemName: "book")
         secondTab.tabBarItem.selectedImage = UIImage(systemName: "book.fill")
 

--- a/TodayAnbu/Sources/Models/MemoData.swift
+++ b/TodayAnbu/Sources/Models/MemoData.swift
@@ -7,7 +7,8 @@
 // MemoView에서 사용하기 위한 더미 Data입니다. 실험이 끝나고 삭제하겠습니다.
 import Foundation
 
-struct MemoData: Hashable {
+struct MemoData: Hashable, Identifiable {
+    let id = UUID().uuidString
     let date: String
     let description: String
 }


### PR DESCRIPTION
## 개요
출시 전 디자인 개선 회의에서 언급된 사항 + 자체 메모뷰 디자인 개선 작업 

## 작업사항
[MainView]
1. 최상단 레이블 위치 하강 및 HStack으로 변경
2. 테이블 뷰 레이블 글자수 키우기
3. 버튼 클릭시 아버지 색상 조절(현재 보라색)
4. 탭뷰 아이템 타이틀 추가
5. 테이블 뷰 셀 색상 연한 회색으로 변경
6. 설정 창 모달에서 완료 버튼 추가

[MemoView]
1. 검색바 및 검색 기능 추가
2. TopArea Round 삭제 및 크기 축소

## References
[검색 키보드 없애는 방법]
https://stackoverflow.com/questions/29925373/how-to-make-keyboard-dismiss-when-i-press-out-of-searchbar-on-swift

[공식문서]
https://developer.apple.com/documentation/uikit/uisearchbar


## 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)
  <img width="200" alt="화면1" src="https://user-images.githubusercontent.com/103009135/183403180-796fb528-0cc3-4378-becf-6eddffb4dc11.PNG">

https://user-images.githubusercontent.com/103009135/183403231-80abed9d-7645-4990-9672-6d6e6507f625.MP4


## 리뷰 포인트
collectionView 구조를 잘 몰라서 켄이 작업한 거 거의 그대로 사용했는데, 코드 정리해야될 거 있으면 알려주세요!
디자인 작업 더 해야되는거 있으면 말씀해주세요

##
출시를 위해 좀만 더 화이팅...
